### PR TITLE
マイページ編集画面の実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,20 +2,41 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    @user = User.find(current_user.id)
+    @user = User.find(params[:id])
     use_days = @user.calc_use_day
     @save_money = @user.calc_save_money(use_days)
     @stop_eat_sweets_day = @user.calc_stop_day
   end
 
-  def update_eat_day
-    user = User.find(current_user.id)
+  def edit
+    @user = User.find(params[:id])
+  end
 
-    if user.eat_day_updated_on != Date.today && user.calc_stop_day > 0
-      user.update!(eat_day: user.eat_day + 1, eat_day_updated_on: Date.today)
+  def update
+    @user = User.find(params[:id])
+    if @user.update(user_params)
+      redirect_to user_path(@user)
+    else
+      flash.now[:alert] = "入力に不備があります。"
+      render :edit
+    end
+  end
+
+  def update_eat_day
+    @user = User.find(params[:id])
+
+    if @user.eat_day_updated_on != Date.today && @user.calc_stop_day > 0
+      @user.update!(eat_day: @user.eat_day + 1, eat_day_updated_on: Date.today)
     else
       flash[:alert] = "本日はこれ以上、申告できません"
     end
-    redirect_back(fallback_location: users_path)
+    redirect_back(fallback_location: user_path(@user))
   end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :cost)
+  end
+
 end

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -1,4 +1,8 @@
 <h1>Tops#index</h1>
 <p>Find me in app/views/tops/index.html.erb</p>
-<%= link_to 'マイページ',users_path %>
+<% if user_signed_in? %>
+  <%= link_to 'マイページ',user_path(current_user) %>
+<% else %>
+  <%= link_to "ログイン", new_user_session_path %>
+<% end %>
 <button type="button" class="btn btn-primary">Primary</button>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,15 @@
+<%= form_with model: @user do |f| %>
+  <div class="form_group">
+    <%= f.label :name, "名前" %>
+    <%= f.text_field :name %>
+  </div>
+  <div class="form_group">
+    <%= f.label :email, "メールアドレス" %>
+    <%= f.email_field :email %>
+  </div>
+  <div class="form_group">
+    <%= f.label :cost, "1日のお菓子にかかっている費用" %>
+    <%= f.number_field :cost %>
+  </div>
+  <%= f.submit "保存", data: { confirm: "更新しますか？"} %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,9 @@
 <%= render partial: 'layouts/flash' %>
-<%= button_to 'お菓子を食べた', update_eat_day_users_path, method: :patch %>
+<%= button_to 'お菓子を食べた', update_eat_day_user_path(@user), method: :patch %>
 <p><%= @user.icon %></p>
 <p><%= @user.name %></p>
+<h2>メールアドレス</h2>
+<p><%= @user.email %></p>
 <h2>開始日</h2>
   <p><%= l @user.created_at %></p>
 <h2>お菓子を辞めてきた日数</h2>
@@ -12,4 +14,6 @@
   <p><%= @user.motivation %></p> 
 <h2>お菓子を辞めれた時のイメージ画像</h2>
   <p><%= @user.goal_image %></p>
+
+  <%= link_to '編集', edit_user_path(@user), class:"btn"  %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,7 @@
 Rails.application.routes.draw do
-  root to: 'tops#index'
-  resource :users, only: :show do
-    collection do
-      patch :update_eat_day
-    end
-  end
   devise_for :users
+  root to: 'tops#index'
+  resources :users do
+    patch :update_eat_day, on: :member
+  end 
 end


### PR DESCRIPTION
close #18

## 実装内容

マイページに登録した内容を編集するための画面を実装
- マイページから編集画面に遷移するためのボタンを実装する
- 編集画面に何も入力せずに保存ボタンを押した場合、マイページ画面に遷移する
- ユーザ名、メールアドレス、1日に使用しているお菓子の金額を編集できるように実装する。他のユーザ情報の編集は別タスクとする

★ Bootstrap でスタイルを付ける作業は別タスクとする

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
