### PR TITLE
マイページの編集画面にバリデーションを実装

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,8 @@
 class User < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :email, length: { maximum: 255 }
+  validates :cost, numericality: { greater_than_or_equal_to: 0 }
+  
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,11 +1,5 @@
 <% if resource.errors.any? %>
   <div id="error_explanation">
-    <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2>
     <ul>
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,10 +13,6 @@
   <p><%= @stop_eat_sweets_day %>日</p>
 <h2>節約した金額</h2>
   <p><%= @save_money %>円</p> 
-<h2>お菓子を辞めたい理由</h2>
-  <p><%= @user.motivation %></p> 
-<h2>お菓子を辞めれた時のイメージ画像</h2>
-  <p><%= @user.goal_image %></p>
 
 <%= button_to '編集', edit_user_registration_path, {method: :get}  %>
 


### PR DESCRIPTION
close #22 

## 実装内容

マイページの編集画面にバリデーションを実装する
- 名前をブランクで入力させないようにする。
- 名前の長さは50文字まで許容する
- メールアドレスの長さは255文字まで許容する 
- 1日にかかっているお菓子の費用は0円以上とする。マイナスの金額を入力できないようにする

以下はdeviseの機能を利用するため、実装不要
- メールアドレスをブランクで入力させないようにする。
- メールアドレスのフォーマットをチェックする。
- メールアドレスを重複して入力させないようにする。また、重複させないようにテーブルの制約にも一位生制約を追加する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
