### PR TITLE
フラッシュのスタイル修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -184,3 +184,9 @@ header {
   padding-top: 10px;
   padding-bottom: 10px;
 }
+
+// フラッシュ
+
+.flash-style {
+  margin-top: 30px;
+}

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,7 +3,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def ensure_normal_user
     if resource.email == "guest@example.com"
-      redirect_to root_path, alert: "ゲストユーザーの更新・削除はできません。"
+      redirect_to user_path(current_user), alert: "ゲストユーザーの更新・削除はできません。"
     end
   end
 

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,5 +1,15 @@
-<% flash.each do |key, value| %>
-    <p class="alert alert-<%= key %>">
-      <%= value %>
-    </p>
-<% end %>
+<div class="container flash-style">
+  <div class="row">
+    <div class="col-lg-3"></div>
+    <div class="col-lg-6">
+        <% flash.each do |key, value| %>
+          <div class="alert alert-primary alert-dismissible fade show alert-signup" role="alert">
+            <%= value %>
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+        <% end %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
close #46 

## 実装内容

以下のフラッシュのスタイルにBootstrapを適用する。
色は「alert-primary」とし、フラッシュの右端にバツボタンを押すことで、消せるようにする
- ログイン成功時、ログアウト成功時
- ログイン失敗時

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## 備考

- ゲストユーザの情報を編集・削除後のページ遷移先を変更