### PR TITLE
つぶやき機能のスタイル修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem 'mini_magick'
 
 gem 'font-awesome-rails'
 
+gem 'kaminari'
+
 group :development, :test do
   # Rails用のテストフレームワーク
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,18 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -268,6 +280,7 @@ DEPENDENCIES
   faker
   font-awesome-rails
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.3)
   mini_magick
   pg (~> 1.1)

--- a/app/assets/stylesheets/_users.scss
+++ b/app/assets/stylesheets/_users.scss
@@ -5,4 +5,7 @@
   margin-top: 10px;
   margin-bottom: 10px;
   margin-left: 10px;
+  border: 2px solid #CCC;
+  background-color: #CCC;
+  box-shadow: 0 2px 2px 0 rgb(0, 0, 0)
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -273,3 +273,28 @@ header {
   float: right;
   display: inline;
 }
+
+.form-content {
+    border: solid 1px #ccc;
+    padding: 30px;
+}
+
+.form-control {
+    display: block;
+    padding: 0.375rem 0.75rem;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #495057;
+    border: 1px solid #ced4da;
+    border-radius: 0.25rem;
+}
+
+.btn-back {
+  display: inline-block;
+  border-radius: 30px;
+  border: none;
+  text-align: center;
+  margin: 15px 15px 5px auto;
+  box-shadow: 0 2px 2px 0 rgb(0, 0, 0) 
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@
 .drawer-menu-item {
   color:#FFF !important;
   margin: 10px 25px;
+  font-size: 18px !important;
 }
 
 .menu-icon {
@@ -39,6 +40,8 @@
 
 .nav-username {
     margin: auto auto 10px 25px;
+    font-size:18px;
+    margin-top: 5px;
 }
 
 header {
@@ -56,6 +59,12 @@ header {
 .navbar-brand {
     font-size: 30px;
     font-family: arial black;
+}
+
+.fa {
+  font-weight:400;
+  display: inline-block !important;
+  line-height:1;
 }
 
 // ログイン画面、アカウント登録、ユーザ情報編集

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -298,3 +298,27 @@ header {
   margin: 15px 15px 5px auto;
   box-shadow: 0 2px 2px 0 rgb(0, 0, 0) 
 }
+
+table {
+  border-collapse:collapse;
+  width: 100%;
+  margin-bottom: 1rem;
+  color: #212529;
+  // border-top: solid 4px #000044;
+}
+
+.post-detail {
+  // margin-top: 50px;
+  margin-bottom: 30px;
+}
+
+th,td {
+  border: 1px solid #dee2e6;;
+  padding: 1rem;
+}
+
+.post-title {
+  margin-top: 50px;
+  border-top: solid 4px #000044;
+  padding: 1rem;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -304,11 +304,9 @@ table {
   width: 100%;
   margin-bottom: 1rem;
   color: #212529;
-  // border-top: solid 4px #000044;
 }
 
 .post-detail {
-  // margin-top: 50px;
   margin-bottom: 30px;
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,11 @@
   color:#FFF !important;
   margin: 10px 25px;
   font-size: 18px !important;
+  text-decoration: none !important;
+}
+
+.drawer-menu-item:hover {
+  color:#007bff !important;
 }
 
 .menu-icon {
@@ -25,40 +30,40 @@
 }
 
 .menu-icon {
-    font-size: 3em;
+  font-size: 3em;
 }
 
 .nav-header {
-    height: 100px;
-    margin: 20px;
+  height: 100px;
+  margin: 20px;
 }
 
 .link_under_none_white {
-    text-decoration: none !important;
-    color: #fff;
+  text-decoration: none !important;
+  color: #fff;
 }
 
 .nav-username {
-    margin: auto auto 10px 25px;
-    font-size:18px;
-    margin-top: 5px;
+  margin: auto auto 10px 25px;
+  font-size:18px;
+  margin-top: 5px;
 }
 
 header {
-    background: #000044;
+  background: #000044;
 }
 
 .drawer-hamburger {
-    display: inline-block;
-    width: 40px;
-    height: 40px;
-    vertical-align: middle;
-    margin: 5px;
+  display: inline-block;
+  width: 40px;
+  height: 40px;
+  vertical-align: middle;
+  margin: 5px;
 }
 
 .navbar-brand {
-    font-size: 30px;
-    font-family: arial black;
+  font-size: 30px;
+  font-family: arial black;
 }
 
 .fa {
@@ -69,43 +74,43 @@ header {
 
 // ログイン画面、アカウント登録、ユーザ情報編集
 .btn-info {
-    display: inline-block;
-    border-radius: 30px;
-    background-color: #FFA500;
-    border: none;
-    text-align: center;
-    margin: 15px 15px 5px auto;
-    box-shadow: 0 2px 2px 0 rgb(0, 0, 0)
+  display: inline-block;
+  border-radius: 30px;
+  background-color: #FFA500;
+  border: none;
+  text-align: center;
+  margin: 15px 15px 5px auto;
+  box-shadow: 0 2px 2px 0 rgb(0, 0, 0)
 }
 
 .signup-form {
-    margin-left: auto;
-    margin-right: auto;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .form-style, .form-title {
-    border: solid 1px #ccc;
-    padding: 10px;
-    border-top: solid 2px #000044;
+  border: solid 1px #ccc;
+  padding: 10px;
+  border-top: solid 2px #000044;
 }
 
 .form-style {
-    margin-top: 30px;
-    box-shadow: 0 2px 2px 0 gray;
-    padding: 0px;
+  margin-top: 30px;
+  box-shadow: 0 2px 2px 0 gray;
+  padding: 0px;
 }
 
 .container {
-    width: 100%;
-    padding-right: 15px;
-    padding-left: 15px;
-    margin-right: auto;
-    margin-left: auto;
+  width: 100%;
+  padding-right: 15px;
+  padding-left: 15px;
+  margin-right: auto;
+  margin-left: auto;
 }
 
 .form-style .form-content {
-    border: solid 1px #ccc;
-    padding: 30px;
+  border: solid 1px #ccc;
+  padding: 30px;
 }
 
 .actions {
@@ -165,11 +170,14 @@ header {
   border-radius: 30px;
   background-color: #000044;
   border: none;
+  box-shadow: 0 2px 2px 0 rgb(0, 0, 0)
+}
+
+.btn-report {
   margin-top: 15px;
   position:absolute;
   top: 10px;
   right: 0px;
-  box-shadow: 0 2px 2px 0 rgb(0, 0, 0)
 }
 
 .user-name-info {
@@ -198,4 +206,70 @@ header {
 
 .flash-style {
   margin-top: 30px;
+}
+
+// 投稿画面
+
+.btn-twitter {
+  margin: 15px 15px 30px auto;
+}
+
+.pagination {
+  margin-top:20px;
+  justify-content: center;
+}
+
+.page-link {
+  color: #FFA500;
+}
+
+.page-item.active .page-link {
+  background-color:#000044 !important;
+}
+
+.post-content {
+  border: dotted 1px silver;
+  height: 250px;
+  margin-top: 10px;
+  padding: 10px;
+}
+
+.user-name {
+  font-size: 1.5em;
+  margin-left: 10px;
+}
+
+.link_under_none {
+  text-decoration: none !important;
+  color: #FFA500;
+}
+
+.content {
+  margin: 0px auto;
+  width: 60%;
+  text-overflow: ellipsis;
+  height: 70px;
+}
+
+.post-icon {
+  text-align: right;
+}
+
+.dislike-info {
+  color:#CCC;
+  text-decoration: none !important;
+}
+
+.like-info {
+  color:#FFA500;
+  text-decoration: none !important;
+}
+
+.dropdown-item {
+  color:#FFA500;  
+}
+
+.dropdown {
+  float: right;
+  display: inline;
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[edit update destroy]
 
   def index
-    @posts = Post.includes(:user, :likes).order(created_at: "DESC")
+    @posts = Post.includes(:user, :likes).order(created_at: "DESC").page(params[:page]).per(5)
   end
 
   def new

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,9 +15,10 @@
             <%=link_to(current_user.name, user_path(current_user), class: "link_under_none_white")%>
           </div>
         </div>
-        <li><%=link_to("ホーム", root_path, class: "drawer-menu-item fa fa-home", 'aria-hidden': true)%></li> 
-        <li><%=link_to("マイページ", user_path(current_user), class: "drawer-menu-item fa fa-address-card", 'aria-hidden': true)%></li> 
-        <li><%=link_to("ログアウト", destroy_user_session_path, method: :delete, class: "drawer-menu-item fa fa-sign-out", 'aria-hidden': true)%></li> 
+        <li><%=link_to(" ホーム", root_path, class: "drawer-menu-item fa fa-home", 'aria-hidden': true)%></li> 
+        <li><%=link_to(" マイページ", user_path(current_user), class: "drawer-menu-item fa fa-address-card", 'aria-hidden': true)%></li> 
+        <li><%=link_to(" ログアウト", destroy_user_session_path, method: :delete, class: "drawer-menu-item fa fa-sign-out", 'aria-hidden': true)%></li> 
+        <li><%=link_to(" つぶやき一覧", posts_path,  class: "drawer-menu-item fa fa-comment", 'aria-hidden': true)%></li> 
       <% else %>
         <%# 非ログイン時 %>
         <div class="nav-header">
@@ -26,10 +27,10 @@
             <%=link_to("ゲストさん", new_user_session_path, class: "link_under_none_white")%>
           </div>
         </div>
-        <li><%=link_to("ホーム", root_path, class: "drawer-menu-item fa fa-home", 'aria-hidden': true)%></li> 
-        <li><%=link_to("ログイン", new_user_session_path, class: "drawer-menu-item fa fa-sign-in", 'aria-hidden': true)%></li>
-        <li><%=link_to("アカウント登録", new_user_registration_path, class: "drawer-menu-item fa fa-user-plus", 'aria-hidden': true)%></li>  
-        <li><%=link_to("ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post, class: "drawer-menu-item")%></li>        
+        <li><%=link_to(" ホーム", root_path, class: "drawer-menu-item fa fa-home", 'aria-hidden': true)%></li> 
+        <li><%=link_to(" ログイン", new_user_session_path, class: "drawer-menu-item fa fa-sign-in", 'aria-hidden': true)%></li>
+        <li><%=link_to(" アカウント登録", new_user_registration_path, class: "drawer-menu-item fa fa-user-plus", 'aria-hidden': true)%></li>  
+        <li><%=link_to(" ゲストログイン（閲覧用）", users_guest_sign_in_path, method: :post, class: "drawer-menu-item")%></li>        
       <% end %> 
     </ul>
   </nav>

--- a/app/views/posts/_dislike.html.erb
+++ b/app/views/posts/_dislike.html.erb
@@ -1,2 +1,2 @@
-<%= link_to "☆", post_likes_path(post), method: :post, remote: true %>
+<%= link_to "", post_likes_path(post), class: "fa fa-heart fa-lg dislike-info", method: :post, remote: true %>
 <%= post.likes_count %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,4 @@
 <%= form_with model: @post, local: true do |f| %>
   <%= f.text_area :content, required: true, size:"20x10", class: "form-control" %><br>
-  <%= f.submit "投稿", class: "btn btn-info btn-lg btn-block" %>
+  <%= f.submit class: "btn btn-info btn-lg btn-block" %>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,4 @@
 <%= form_with model: @post, local: true do |f| %>
-  <%= f.text_area :content, required: true %><br>
-  <%= f.submit "投稿" %>
+  <%= f.text_area :content, required: true, size:"20x10", class: "form-control" %><br>
+  <%= f.submit "投稿", class: "btn btn-info btn-lg btn-block" %>
 <% end %>

--- a/app/views/posts/_like.html.erb
+++ b/app/views/posts/_like.html.erb
@@ -1,2 +1,2 @@
-<%= link_to "★", post_likes_path(post), method: :delete, remote: true %>
+<%= link_to "", post_likes_path(post), class: "fa fa-heart fa-lg like-info", method: :delete, remote: true %>
 <%= post.likes_count %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -25,25 +25,12 @@
     <p><%= post.content %></p>
   </div>
   <div class="post-icon">
-  <p id="post-<%= post.id %>">
-    <% if post.liked_by?(current_user) %>
-      <%= render "like", post: post %>
-    <% else %>
-      <%= render "dislike", post: post %>
-    <% end %>
-  </p>
+    <p id="post-<%= post.id %>">
+      <% if post.liked_by?(current_user) %>
+        <%= render "like", post: post %>
+      <% else %>
+        <%= render "dislike", post: post %>
+      <% end %>
+    </p>
   </div>
-<%
-=begin
-%>  
-  <p>
-    <%= link_to "詳細", post %>
-    <% if current_user.id == post.user_id %>
-      <%= link_to "編集", edit_post_path(post) %>
-      <%= link_to "削除", post_path(post), method: :delete, data: { confirm: "削除しますか？" } %>
-    <% end %>  
-  </p>
-<%
-=end
-%>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,12 +1,30 @@
-<div>
+<div class="post-content">
   <% if post.user.image? %>
     <%= image_tag post.user.image.url, class: "show_image" %>
   <% else %>
     <%= image_tag 'no-image.png', class: "show_image" %>
   <% end %>
 
-  <p><%= post.user.name %></p>
-  <p><%= post.content %></p>
+  <strong class="user-name">
+    <%= link_to post.user.name, user_path(post.user), class:"link_under_none" %>
+  </strong>
+  <div class="dropdown">
+    <button class="btn fa fa-ellipsis-v" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    </button>
+    <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+      <%= link_to "詳細", post, class:"dropdown-item" %>
+      <% if current_user.id == post.user_id %>
+        <div class="dropdown-divider"></div>
+        <%= link_to "編集", edit_post_path(post), class:"dropdown-item" %>
+        <div class="dropdown-divider"></div>
+        <%= link_to "削除", post_path(post), method: :delete, data: { confirm: "削除しますか？" }, class:"dropdown-item" %>
+      <% end %>
+    </div>
+  </div>
+  <div class="content">
+    <p><%= post.content %></p>
+  </div>
+  <div class="post-icon">
   <p id="post-<%= post.id %>">
     <% if post.liked_by?(current_user) %>
       <%= render "like", post: post %>
@@ -14,6 +32,10 @@
       <%= render "dislike", post: post %>
     <% end %>
   </p>
+  </div>
+<%
+=begin
+%>  
   <p>
     <%= link_to "詳細", post %>
     <% if current_user.id == post.user_id %>
@@ -21,5 +43,7 @@
       <%= link_to "削除", post_path(post), method: :delete, data: { confirm: "削除しますか？" } %>
     <% end %>  
   </p>
+<%
+=end
+%>
 </div>
-<hr>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,3 +1,17 @@
-<h1>編集</h1>
-<%= render "devise/shared/error_messages", resource: @post %>
-<%= render "form" %>
+<div class="container">
+  <div class="row">
+    <div class="col-md-3"></div>
+    <div class="col-md-6">
+      <div class="form-style">
+        <div class="form-title">
+          <h6><strong>編集</strong></h6>
+        </div>
+        <div class="form-content">
+          <%= render "devise/shared/error_messages", resource: @post %>
+          <%= render "form" %>
+          <%= link_to("戻る", posts_path,  class: "btn btn-secondary btn-lg btn-block btn-back") %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,11 @@
-<%= link_to "つぶやく", new_post_path %>
-<%= paginate @posts %>
-<%= render @posts %>
-<%= paginate @posts %>
+<div class="container">
+  <div class="row">
+  <div class="col-lg-3"></div>
+    <div class="col-lg-6">
+      <%= paginate @posts %>
+      <%= link_to "つぶやく", new_post_path, class: "btn btn-primary btn-lg btn-block btn-twitter" %>
+      <%= render @posts %>
+      <%= paginate @posts %>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,3 +1,4 @@
-<h1>投稿一覧画面</h1>
-<%= link_to "投稿", new_post_path %>
+<%= link_to "つぶやく", new_post_path %>
+<%= paginate @posts %>
 <%= render @posts %>
+<%= paginate @posts %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,3 +1,17 @@
-<h1>ユーザ投稿画面</h1>
-<%= render "devise/shared/error_messages", resource: @post %>
-<%= render "form" %>
+<div class="container">
+  <div class="row">
+    <div class="col-md-3"></div>
+    <div class="col-md-6">
+      <div class="form-style">
+        <div class="form-title">
+          <h6><strong>つぶやき</strong></h6>
+        </div>
+        <div class="form-content">
+          <%= render "devise/shared/error_messages", resource: @post %>
+          <%= render "form" %>
+          <%= link_to("戻る", posts_path,  class: "btn btn-secondary btn-lg btn-block btn-back") %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,18 +1,36 @@
-<h1>投稿詳細</h1>
-<p>【名前】 <%= @post.user.name %></p>
-<p>【内容】 <%= @post.content %></p>
-<p>【作成日】 <%= l @post.created_at %></p>
-<p id="post-<%= @post.id %>">
-  <% if @post.liked_by?(current_user) %>
-    <%= render "like", post: @post %>
-  <% else %>
-    <%= render "dislike", post: @post %>
-  <% end %>
-</p>
-<% if current_user.id == @post.user_id %>
-  <p>
-    <%= link_to "編集", edit_post_path(@post) %>
-    <%= link_to "削除", post_path(@post), method: :delete, data: { confirm: "削除しますか？" } %>
-  </p>
-<% end %>
-<p><%= link_to "投稿一覧へ", posts_path %></p>
+<div class="container">
+  <div class="row">
+    <div class="col-md-3"></div>
+    <div class="col-md-6">
+      <div class="form-title post-title">
+        <h6><strong>詳細</strong></h6>
+      </div>
+      <table class="post-detail">
+        <tr>
+          <th>名前</th>
+          <td><%= @post.user.name %></td>
+        </tr>
+        <tr>
+          <th>内容</th>
+          <td><%= @post.content %></td>
+        </tr>
+        <tr>
+          <th>作成日</th>
+          <td><%= l @post.created_at %></td>
+        </tr>
+      </table>
+      <p id="post-<%= @post.id %>">
+        <% if @post.liked_by?(current_user) %>
+          <%= render "like", post: @post %>
+        <% else %>
+          <%= render "dislike", post: @post %>
+        <% end %>
+      </p>
+      <% if current_user.id == @post.user_id %>
+        <%= link_to("編集", edit_post_path(@post),  class: "btn btn-info btn-lg btn-block btn-back") %>
+        <%= link_to("削除", post_path(@post), method: :delete, data: { confirm: "削除しますか？" },  class: "btn btn-info btn-lg btn-block btn-back") %>
+      <% end %>
+      <%= link_to("戻る", posts_path,  class: "btn btn-secondary btn-lg btn-block btn-back") %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,9 +1,11 @@
 <div class="container">
   <div class="row">
     <div class="col-md-6 signup-form">
-      <div class="report-button">
-        <%=link_to("お菓子を食べた", update_eat_day_user_path(@user), method: :patch, class: "btn btn-primary")%>
-      </div>
+      <% if current_user.id == @user.id %>
+        <div class="report-button">
+          <%=link_to("お菓子を食べた", update_eat_day_user_path(@user), method: :patch, class: "btn btn-primary btn-report")%>
+        </div>
+      <% end %>  
       <div class="user-image">
         <div class="image-circle">
           <% if @user.image? %>
@@ -40,10 +42,12 @@
       <div class="user-data">
         <%= @save_money %>円
       </div>
-      <div class="mypage-button-info">
-        <%=link_to("編集", edit_user_registration_path, class: "btn btn-info mypage-button")%>
-        <%=link_to("削除", user_registration_path, method: :delete, class: "btn btn-info mypage-button", data: { confirm: '本当に削除しますか？' } )%>
-      </div>
+      <% if current_user.id == @user.id %>
+        <div class="mypage-button-info">
+          <%=link_to("編集", edit_user_registration_path, class: "btn btn-info mypage-button")%>
+          <%=link_to("削除", user_registration_path, method: :delete, class: "btn btn-info mypage-button", data: { confirm: '本当に削除しますか？' } )%>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,3 +13,6 @@ ja:
       like:
         user: ユーザー
         post: 投稿
+  helpers:
+    submit:
+      create: 投稿する

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,8 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."


### PR DESCRIPTION
close #48 

## 実装内容

- ナビバーにつぶやき機能に遷移できるようにする
- ユーザ投稿一覧画面およびつぶやき投稿のスタイルにBootstrapを適用する
- 投稿一覧をページネーション化するためにgem「kaminari」を使用する。
また、`config/locales`フォルダに`kaminari_ja.yml`というファイルを作成し、kaminariを日本語化する
- つぶやき投稿画面およびつぶやきの編集から投稿一覧画面に戻れるようにする

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
