### PR TITLE
モデルスペックおよびリクエストスペックを追加

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post, counter_cache: :comments_count
-  validates :content, presence: true
+  validates :content, presence: true, length: { maximum: 140 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,15 +25,11 @@ class User < ApplicationRecord
   end
 
   def calc_use_day_month
-    if Date.today.beginning_of_month > self.created_at
+    if Date.today.beginning_of_month >= self.created_at
       (Date.today - Date.today.beginning_of_month).to_i
     else
       (Date.today - self.created_at.to_date).to_i
     end
-  end
-
-  def calc_stop_day
-    self.calc_use_day - self.eat_day
   end
 
   def calc_stop_day_month

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :comment do
-    content { "MyText" }
-    user { nil }
-    post { nil }
+    content { Faker::Lorem.paragraph }
+    user
+    post
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -4,4 +4,8 @@ FactoryBot.define do
     user
     post
   end
+
+  trait :comment_invalid do
+    content { nil }
+  end
 end

--- a/spec/factories/post.rb
+++ b/spec/factories/post.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     user
   end
 
-  trait :invalid do
+  trait :post_invalid do
     content { nil }
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,5 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe Comment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "バリデーション" do
+    subject { comment.valid? }
+      context "データが条件を満たすとき" do
+        let(:comment) { build(:comment) }
+        it "保存できる" do
+          expect(subject).to eq true
+        end
+      end
+      context "content が空のとき" do
+        let(:comment) { build(:comment, content: "") }
+        it "エラーが発生する" do
+          expect(subject).to eq false
+          expect(comment.errors.messages[:content]).to include "を入力してください"
+        end
+      end
+      context "content  が141文字以上のとき" do
+        let(:comment) { build(:comment, content: "a" * 141) }
+        it "エラーが発生する" do
+          expect(subject).to eq false
+          expect(comment.errors.messages[:content]).to include "は140文字以内で入力してください"
+        end
+      end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -79,6 +79,30 @@ RSpec.describe User, type: :model do
           expect(user.calc_stop_day).to eq 1
       end
     end
+    context "ユーザ登録した日が前月末の場合で、calc_use_day_month のデータが条件を満たすとき" do
+      let(:user) { build(:user, created_at: Date.today.beginning_of_month - 1) }
+      it "ユーザの月のサービス利用日数が想定通りになる" do
+        expect(user.calc_use_day_month).to eq (Date.today - Date.today.beginning_of_month).to_i
+      end
+    end
+    context "ユーザ登録した日が月初1日の場合で、calc_use_day_month のデータが条件を満たすとき" do
+      let(:user) { build(:user, created_at: Date.today.beginning_of_month) }
+      it "ユーザの月のサービス利用日数が想定通りになる" do
+        expect(user.calc_use_day_month).to eq (Date.today - Date.today.beginning_of_month).to_i
+      end
+    end
+    context "ユーザ登録した日が月初2日の場合で、calc_use_day_month のデータが条件を満たすとき" do
+      let(:user) { build(:user, created_at: Date.today.beginning_of_month + 1) }
+      it "ユーザの月のサービス利用日数が想定通りになる" do
+        expect(user.calc_use_day_month).to eq (Date.today - user.created_at.to_date).to_i
+      end
+    end
+    context "calc_stop_day_month のデータが条件を満たすとき" do
+      let(:user) { build(:user, created_at: Date.today.beginning_of_month - 1, eat_day_month:1) }
+      it "お菓子を辞めた合計日数から食べてしまった日数を差し引いた日数が想定通りになる" do
+          expect(user.calc_stop_day_month).to eq (Date.today - Date.today.beginning_of_month - 1).to_i
+      end
+    end
   end
 
   describe "クラスメソッド" do

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -1,0 +1,185 @@
+require 'rails_helper'
+
+RSpec.describe "Comments", type: :request do
+  describe  "Logind" do
+    let(:user) { create(:user) }
+    before do
+      sign_in user
+    end
+
+    describe "GET #new" do
+      subject { get(new_post_comments_path(post_id)) }
+      let(:post) { create(:post) }
+      let(:post_id) { post.id }
+
+      it "リクエストが成功する" do
+        subject
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe "POST #create" do
+      subject { post(post_comments_path(post_id), params: params) }
+      let(:post_val) { create(:post) }
+      let(:post_id) { post_val.id }
+
+      context "パラメータが正常なとき" do
+        let(:params) { { comment: attributes_for(:comment) } }
+
+        it "リクエストが成功する" do
+          subject
+          expect(response).to have_http_status(302)
+        end
+
+        it "コメントが保存される" do
+          expect { subject }.to change { Comment.count }.by(1)
+        end
+
+        it "投稿詳細ページにリダイレクトされる" do
+          subject
+          expect(response).to redirect_to post_path(post_id)
+        end
+      end
+
+      context "パラメータが異常なとき" do
+        let(:params) { { comment: attributes_for(:comment, :comment_invalid) } }
+
+        it "レンダリングが成功する" do
+          subject
+          expect(response).to have_http_status(200)
+        end
+
+        it "コメントが保存されない" do
+          expect { subject }.not_to change(Comment, :count)
+        end
+
+        it "ユーザ投稿画面ページがレンダリングされる" do
+          subject
+          expect(response.body).to include "コメントする"
+        end
+      end
+    end
+
+    describe "GET #edit" do
+      before do
+        create(:comment, user_id: user.id, post_id: post.id)
+      end
+      subject { get(edit_post_comment_path(id: comment_post_id, post_id: comment_id)) }
+      let(:post) { create(:post) }
+      let(:comment_post_id) { post.comments[0].post_id }
+
+      context "コメントが存在するとき" do
+        let(:comment_id) { post.comments[0].id }
+        it "リクエストが成功する" do
+          subject
+          expect(response).to have_http_status(200)
+        end
+
+        it "content が表示されている" do
+          subject
+          expect(response.body).to include post.comments[0].content
+        end
+      end
+
+      context "idに対応するコメントが存在しないとき" do
+        let(:comment_id) { 1 }
+
+        it "エラーが発生する" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+
+    describe 'PATCH #update' do
+      before do
+        create(:comment, user_id: user.id, post_id: post.id)
+      end
+      subject { patch(post_comment_path(id: comment_id, post_id: comment_post_id, params: params)) }
+      let(:post) { create(:post) }
+      let(:comment_post_id) { post.comments[0].post_id }
+      let(:comment_id) { post.comments[0].id }
+      let(:comment) { create(:comment, user_id: user.id, post_id: post.id) }
+
+      context 'パラメータが正常な場合' do
+        let(:params) { { comment: attributes_for(:comment) } }
+
+        it 'リクエストが成功する' do
+          subject
+          expect(response).to have_http_status(302)
+        end
+
+        it 'content が更新される' do
+          origin_content = post.comments[0].content
+          new_content = params[:comment][:content]
+          expect { subject }.to change { post.comments[0].reload.content }.from(origin_content).to(new_content)
+        end
+
+        it "投稿詳細ページにリダイレクトされる" do
+          subject
+          expect(response).to redirect_to post_path(comment_post_id)
+        end
+      end
+
+      context 'パラメータが異常なとき' do
+        let(:params) { { comment: attributes_for(:comment, :comment_invalid) } }
+
+        it 'リクエストが成功する' do
+          subject
+          expect(response).to have_http_status(200)
+        end
+
+        it 'content が更新されない' do
+          expect { subject }.not_to change(post.comments[0].reload, :content)
+        end
+
+        it '編集ページがレンダリングされる' do
+          subject
+          expect(response.body).to include 'コメント編集'
+        end
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      before do
+        create(:comment, user_id: user.id, post_id: post.id)
+      end
+      subject { delete(post_comment_path(id: comment_post_id, post_id: comment_id)) }
+      let(:post) { create(:post) }
+      let!(:comment_post_id) { post.comments[0].post_id }
+      let!(:comment_id) { post.comments[0].id }
+
+      context 'パラメータが正常な場合' do
+        it 'リクエストが成功する' do
+          subject
+          expect(response).to have_http_status(302)
+        end
+
+        it 'コメントが削除される' do
+          expect { subject }.to change(Comment, :count).by(-1)
+        end
+
+        it '投稿一覧にリダイレクトすること' do
+          subject
+          expect(response).to redirect_to(post_path(comment_post_id))
+        end
+      end
+    end
+  end
+  describe  "Not Logged in" do
+    describe "GET #new" do
+      subject { get(new_post_comments_path(post_id)) }
+      let(:post) { create(:post) }
+      let(:post_id) { post.id }
+
+      it "リダイレクトが成功する" do
+        subject
+        expect(response).to have_http_status(302)
+      end
+
+      it "ログインページにリダイレクトされる" do
+        subject
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -64,18 +64,18 @@ RSpec.describe "Posts", type: :request do
       end
 
       context "パラメータが異常なとき" do
-        let(:params) { { post: attributes_for(:post, :invalid) } }
+        let(:params) { { post: attributes_for(:post, :post_invalid) } }
 
         it "レンダリングが成功する" do
           subject
           expect(response).to have_http_status(200)
         end
 
-        it "ユーザーが保存されない" do
+        it "投稿が保存されない" do
           expect { subject }.not_to change(Post, :count)
         end
 
-        it "ユーザ投稿画面ページがレンダリングされる" do
+        it "コメント投稿画面ページにレンダリングされる" do
           subject
           expect(response.body).to include "つぶやき"
         end
@@ -158,7 +158,7 @@ RSpec.describe "Posts", type: :request do
       end
 
       context 'パラメータが異常なとき' do
-        let(:params) { { post: attributes_for(:post, :invalid) } }
+        let(:params) { { post: attributes_for(:post, :post_invalid) } }
 
         it 'リクエストが成功する' do
           subject


### PR DESCRIPTION
close #65

## 実装内容

- commentテーブルおよびコントローラーを追加したことにより、モデルスペックおよびリエスとスペックを追加
- モデルスペックは以下のケースを実施予定
    - 正常系
    - 異常系
        - content、user_id、post_idがnullのケース 
        - contentが140文字を超えるケース

- リクエストスペックは以下のケースを実施予定
    - 正常系
    - 異常系
        - ログインしていない状態からコメントしようとするケース
        - パラメーターが異常なケース
        - idに対するコメントが存在しないケース

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## 備考

- Userモデルにロジックを追加したことに伴い、モデルスペックを追加
