### PR TITLE
マイページのレスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -90,12 +90,6 @@ header {
   box-shadow: 0 2px 2px 0 rgb(0, 0, 0)
 }
 
-.signup-form {
-  margin-left: auto;
-  margin-right: auto;
-  margin-bottom: 50px;
-}
-
 .form-style, .form-title {
   border: solid 1px #ccc;
   padding: 10px;
@@ -127,17 +121,8 @@ header {
 
 // マイページ
 
-.image-circle {
-  display: inline-block;
-  border: 1px solid #ccc;
-  border-radius: 50%;
-  overflow: hidden;
-}
-
 .user-image {
-  text-align: center;
-  margin-top:40px;
-  margin-bottom:20px;
+  margin-top: 100px;
 }
 
 .show-image {
@@ -148,6 +133,7 @@ header {
   margin: 0px;
   border: 2px solid #CCC;
   background-color: #CCC;
+  box-shadow: 0 4px 4px 0 black;
 }
 
 .mypage-button-info {
@@ -165,48 +151,12 @@ header {
   box-shadow: 0 2px 2px 0 rgb(0, 0, 0)
 }
 
-.report-button {
-  width: 510px;
-  height: 50px;
-  position:relative;
-}
-
 .btn-primary {
   display: inline-block;
   border-radius: 30px;
   background-color: #000044;
   border: none;
   box-shadow: 0 2px 2px 0 rgb(0, 0, 0)
-}
-
-.btn-report {
-  margin-top: 15px;
-  position:absolute;
-  top: 10px;
-  right: 0px;
-}
-
-.user-name-info {
-  text-align: center;
-  margin-bottom: 50px;
-}
-
-.user-other-info {
-  background: #f4f4f4;
-  border: 1px solid rgba(0,0,0,0.1);
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-left: 20px;
-  font-size: 20px;
-}
-
-.user-data {
-  border: 1px solid rgba(0,0,0,0.1);
-  padding-left: 20px;
-  font-size: 18px;
-  padding-top: 10px;
-  padding-bottom: 10px;
-  word-wrap: break-word;
 }
 
 // フラッシュ

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,38 +1,40 @@
 <div class="container">
-  <div class="col-md-6 signup-form">
-    <div class="form-style">
-      <div class="form-title">
-        <h6><strong>ユーザ情報編集</strong></h6>
-      </div>
-      <div class="form-content">
-        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-          <%= bootstrap_devise_error_messages! %>
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <div class="form-style">
+        <div class="form-title">
+          <h6><strong>ユーザ情報編集</strong></h6>
+        </div>
+        <div class="form-content">
+          <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+            <%= bootstrap_devise_error_messages! %>
 
-          <div class="form-group">
-            <%= f.label :name %>
-            <%= f.text_field :name, autofocus: true, autocomplete: 'name', class: 'form-control', maxlength: '50' %>
-          </div>
+            <div class="form-group">
+              <%= f.label :name %>
+              <%= f.text_field :name, autofocus: true, autocomplete: 'name', class: 'form-control', maxlength: '50' %>
+            </div>
 
-          <div class="form-group">
-            <%= f.label :email %>
-            <%= f.email_field :email, autocomplete: 'email', class: 'form-control', maxlength: '255' %>
-          </div>
-          
-          <div class="form-group">
-            <%= f.label :cost %>
-            <%= f.number_field :cost, class: 'form-control', min: 0 %>
-          </div>
+            <div class="form-group">
+              <%= f.label :email %>
+              <%= f.email_field :email, autocomplete: 'email', class: 'form-control', maxlength: '255' %>
+            </div>
+            
+            <div class="form-group">
+              <%= f.label :cost %>
+              <%= f.number_field :cost, class: 'form-control', min: 0 %>
+            </div>
 
-          <div class="form-group">
-            <%= f.label :image %><br>
-            <%= f.file_field :image, accept: "image/png,image/jpeg,image/gif" %>
-          </div>
+            <div class="form-group">
+              <%= f.label :image %><br>
+              <%= f.file_field :image, accept: "image/png,image/jpeg,image/gif" %>
+            </div>
 
-          <div class="form-group">
-            <%= f.submit t('.update'), class: 'btn btn-info btn-lg btn-block' %>
-          </div>
-        <% end %>
-      </div>
-    </div>    
+            <div class="form-group">
+              <%= f.submit t('.update'), class: 'btn btn-info btn-lg btn-block' %>
+            </div>
+          <% end %>
+        </div>
+      </div>    
+    </div>
   </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
-  <div class="row">
-    <div class="col-md-6 signup-form">
+  <div class="row justify-content-center">
+    <div class="col-md-6">
       <div class="form-style">
         <div class="form-title">
           <h6><strong>アカウント登録</strong></h6>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,36 +1,38 @@
 <div class="container">
-  <div class="col-md-6 signup-form">
-    <div class="form-style">
-      <div class="form-title">
-        <h6><strong>ログイン</strong></h6>
-      </div>
-      <div class="form-content">
-        <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-          <div class="form-group">
-            <%= f.label :email %>
-            <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control', required: true, maxlength: '255' %>
-          </div>
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <div class="form-style">
+        <div class="form-title">
+          <h6><strong>ログイン</strong></h6>
+        </div>
+        <div class="form-content">
+          <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+            <div class="form-group">
+              <%= f.label :email %>
+              <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control', required: true, maxlength: '255' %>
+            </div>
 
-          <div class="form-group">
-            <%= f.label :password %>
-            <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control', required: true %>
-          </div>
+            <div class="form-group">
+              <%= f.label :password %>
+              <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control', required: true %>
+            </div>
 
-          <% if devise_mapping.rememberable? %>
-            <div class="form-group form-check">
-              <%= f.check_box :remember_me, class: 'form-check-input' %>
-              <%= f.label :remember_me, class: 'form-check-label' do %>
-                <%= resource.class.human_attribute_name('remember_me') %>
-              <% end %>
+            <% if devise_mapping.rememberable? %>
+              <div class="form-group form-check">
+                <%= f.check_box :remember_me, class: 'form-check-input' %>
+                <%= f.label :remember_me, class: 'form-check-label' do %>
+                  <%= resource.class.human_attribute_name('remember_me') %>
+                <% end %>
+              </div>
+            <% end %>
+
+            <div class="actions">
+              <%= f.submit  t('.sign_in'), class: 'btn btn-info btn-lg btn-block' %>
             </div>
           <% end %>
-
-          <div class="actions">
-            <%= f.submit  t('.sign_in'), class: 'btn btn-info btn-lg btn-block' %>
-          </div>
-        <% end %>
-        <%= render 'devise/shared/links' %>
-      </div>
-    </div>    
+          <%= render 'devise/shared/links' %>
+        </div>
+      </div>    
+    </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,61 +1,61 @@
 <div class="container">
-  <div class="row">
-    <div class="col-md-6 signup-form">
+  <div class="row justify-content-center">
+    <div class="col-lg-6">
       <% if current_user.id == @user.id %>
-        <div class="report-button">
-          <%=link_to("お菓子を食べた", update_eat_day_user_path(@user), method: :patch, class: "btn btn-primary btn-report")%>
+        <div class="text-right">
+          <%=link_to("お菓子を食べた", update_eat_day_user_path(@user), method: :patch, class: "btn btn-primary mt-3")%>
         </div>
       <% end %>  
-      <div class="user-image">
-        <div class="image-circle">
-          <% if @user.image? %>
-            <%= image_tag @user.image.url, class: "show-image" %>
-          <% else %>
-            <%= image_tag 'no-image.png', class: "show-image" %>
-          <% end %>
-        </div>
+      <div class="user-image text-center mb-4">
+        <% if @user.image? %>
+          <%= image_tag @user.image.url, class: "show-image rounded-circle" %>
+        <% else %>
+          <%= image_tag 'no-image.png', class: "show-image rounded-circle" %>
+        <% end %>
       </div>
-      <div class="user-name-info">
+      <div class="text-center mb-5">
         <h4><strong><%= @user.name %></strong></h4>
       </div>
-      <% if current_user.id == @user.id %>
-        <div class="user-other-info">
-          <strong>メールアドレス</strong>
-        </div>
-        <div class="user-data">
-          <%= @user.email %>
-        </div>
-      <% end %>  
-      <div class="user-other-info">
-        <strong>サービス利用開始日</strong>
-      </div>
-      <div class="user-data">
-        <%= l @user.created_at %>
-      </div>
-      <div class="user-other-info">
-        <strong>サービス利用開始からお菓子を辞めた日数</strong>
-      </div>
-      <div class="user-data">
-        <%= @stop_eat_sweets_day %>日
-      </div>
-      <div class="user-other-info">
-        <strong>サービス利用開始から節約した金額</strong>
-      </div>
-      <div class="user-data">
-        <%= @save_money %>円
-      </div>
-      <div class="user-other-info">
-        <strong>今月のお菓子を辞めた日数</strong>
-      </div>
-      <div class="user-data">
-        <%= @stop_eat_sweets_day_month %>日
-      </div>
-      <div class="user-other-info">
-        <strong>今月の節約した金額</strong>
-      </div>
-      <div class="user-data">
-        <%= @save_money_month %>円
-      </div>
+      <table class="table table-striped table-bordered">
+        <% if current_user.id == @user.id %>
+          <tr>
+            <th class="h5"><strong>メールアドレス</strong></th>
+          </tr>
+          <tr>
+            <th class="font-weight-normal"><%= @user.email %></th>
+          </tr>
+        <% end %>
+        <tr>
+          <th class="h5"><strong>サービス利用開始日</strong></th>
+        </tr>
+        <tr>
+          <th class="font-weight-normal"><%= l @user.created_at %></th>
+        </tr>
+        <tr>
+          <th class="h5"><strong>サービス利用開始からお菓子を辞めた日数</strong></th>
+        </tr>
+        <tr>
+          <th class="font-weight-normal"><%= @stop_eat_sweets_day %>日</th>
+        </tr>
+        <tr>
+          <th class="h5"><strong>サービス利用開始から節約した金額</strong></th>
+        </tr>
+        <tr>
+          <th class="font-weight-normal"><%= @save_money %>円</th>
+        </tr>
+        <tr>
+          <th class="h5"><strong>今月のお菓子を辞めた日数</strong></th>
+        </tr>
+        <tr>
+          <th class="font-weight-normal"><%= @stop_eat_sweets_day_month %>日</th>
+        </tr>
+        <tr>
+          <th class="h5"><strong>今月の節約した金額</strong></th>
+        </tr>
+        <tr>
+          <th class="font-weight-normal"><%= @save_money_month %>円</th>
+        </tr>
+      </table>
       <% if current_user.id == @user.id %>
         <div class="mypage-button-info">
           <%=link_to("編集", edit_user_registration_path, class: "btn btn-info mypage-button")%>


### PR DESCRIPTION
close #68

## 実装内容

- スマートフォン画面で見た際に、お菓子を食べたことを申告するボタンを右にスクロールせずに見えるようにする。
- ヘッダーのロゴが右にスクロールせずに表示されるようにする。

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
