### PR TITLE
本番環境でアセットパイプラインが動くように設定を変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
close #74 

## 実装内容

- herokuでアセットパイプラインが動くように以下のように修正する
「config/environments/production.rb」のconfig.assets.compileの設定が「false」から「true」に書き換える

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
