### PR TITLE
ニュース機能に関するモデル・コントローラー・ビューを作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -488,3 +488,17 @@ td {
   margin-top: 100px;
   margin-bottom: 100px;
 }
+
+// ニュース機能
+.posted_day {
+  font-size: 18px;
+  color: rgba(0,0,0,0.6);
+  line-height: 1.8;
+}
+
+.link_under_none_post {
+  text-decoration: none !important;
+  font-weight: 700;
+  color: rgba(0,0,0,0.87);
+  line-height: 1.5;
+}

--- a/app/controllers/informations_controller.rb
+++ b/app/controllers/informations_controller.rb
@@ -1,0 +1,9 @@
+class InformationsController < ApplicationController
+  def index
+    @informations = Information.all.order(created_at: :desc)
+  end
+
+  def show
+    @information = Information.find(params[:id])
+  end
+end

--- a/app/models/information.rb
+++ b/app/models/information.rb
@@ -1,0 +1,4 @@
+class Information < ApplicationRecord
+  validates :title, presence: true
+  validates :content, presence: true
+end

--- a/app/views/informations/_information.html.erb
+++ b/app/views/informations/_information.html.erb
@@ -1,2 +1,11 @@
-<%# <%= information.title %>
-<%= link_to information.title, information_path(information.id), class:"link_under_none" %>
+<table class="table">
+  <tbody>
+    <tr>
+      <td>
+        <p class="posted_day"><%= l information.updated_at %>に投稿</p>
+        <h2><%= link_to information.title, information_path(information.id), class:"link_under_none_post" %></h2>
+      </td>
+    </tr>
+  </tbody>
+</table>
+      

--- a/app/views/informations/_information.html.erb
+++ b/app/views/informations/_information.html.erb
@@ -1,0 +1,2 @@
+<%# <%= information.title %>
+<%= link_to information.title, information_path(information.id), class:"link_under_none" %>

--- a/app/views/informations/index.html.erb
+++ b/app/views/informations/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-lg-3"></div>
-      <div class="col-lg-6">
+      <div class="col-lg-7">
         <%= render partial: 'information', collection: @informations %>
       </div>
     </div>

--- a/app/views/informations/index.html.erb
+++ b/app/views/informations/index.html.erb
@@ -1,0 +1,9 @@
+<div class="container">
+  <div class="row">
+    <div class="col-lg-3"></div>
+      <div class="col-lg-6">
+        <%= render partial: 'information', collection: @informations %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/informations/show.html.erb
+++ b/app/views/informations/show.html.erb
@@ -1,0 +1,9 @@
+<div class="container">
+  <div class="row">
+    <div class="col-lg-3"></div>
+    <div class="col-lg-6">
+      <%= @information.content %>
+      <%= link_to("戻る", informations_path,  class: "btn btn-secondary btn-lg btn-block btn-back") %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,9 +17,10 @@
         </div>
         <li><%=link_to(" ホーム", root_path, class: "drawer-menu-item fa fa-home", 'aria-hidden': true)%></li> 
         <li><%=link_to(" マイページ", user_path(current_user), class: "drawer-menu-item fa fa-address-card", 'aria-hidden': true)%></li> 
-        <li><%=link_to(" ログアウト", destroy_user_session_path, method: :delete, class: "drawer-menu-item fa fa-sign-out", 'aria-hidden': true)%></li> 
+        <li><%=link_to(" ログアウト", destroy_user_session_path, method: :delete, class: "drawer-menu-item fa fa-sign-out-alt", 'aria-hidden': true)%></li> 
         <li><%=link_to(" つぶやき一覧", posts_path,  class: "drawer-menu-item fa fa-comment", 'aria-hidden': true)%></li> 
         <li><%=link_to(" ランキング", users_path,  class: "drawer-menu-item fa fa-trophy", 'aria-hidden': true)%></li> 
+        <li><%=link_to(" ニュース一覧", informations_path,  class: "drawer-menu-item fa fa-newspaper", 'aria-hidden': true)%></li>
       <% else %>
         <%# 非ログイン時 %>
         <div class="nav-header">
@@ -29,9 +30,9 @@
           </div>
         </div>
         <li><%=link_to(" ホーム", root_path, class: "drawer-menu-item fa fa-home", 'aria-hidden': true)%></li> 
-        <li><%=link_to(" ログイン", new_user_session_path, class: "drawer-menu-item fa fa-sign-in", 'aria-hidden': true)%></li>
+        <li><%=link_to(" ログイン", new_user_session_path, class: "drawer-menu-item fa fa-sign-in-alt", 'aria-hidden': true)%></li>
         <li><%=link_to(" アカウント登録", new_user_registration_path, class: "drawer-menu-item fa fa-user-plus", 'aria-hidden': true)%></li>  
-        <li><%=link_to(" ゲストログイン", users_guest_sign_in_path, method: :post, class: "drawer-menu-item fa fa-sign-in", 'aria-hidden': true)%></li>        
+        <li><%=link_to(" ゲストログイン", users_guest_sign_in_path, method: :post, class: "drawer-menu-item fa fa-sign-in-alt", 'aria-hidden': true)%></li>
       <% end %> 
     </ul>
   </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/iScroll/5.1.3/iscroll.min.js"></script>
     <%# drawer.js %>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/drawer/3.2.1/js/drawer.min.js"></script>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/all.css" integrity="sha384-SZXxX4whJ79/gErwcOYf+zWLeJdY/qpuqC4cAa9rOGUstPomtqpuNWT9wdPEn2fk" crossorigin="anonymous">
   </head>
 
   <body class="drawer drawer--left" style="padding-top: 5rem">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,19 +1,20 @@
 <div class="container">
   <div class="row">
-  <div class="col-lg-3"></div>
-    <div class="col-lg-6 mb-lg-5">
-      <%= paginate @posts %>
-      <%= link_to "つぶやく", new_post_path, class: "btn btn-primary btn-lg btn-block btn-twitter" %>
-      <%= render @posts %>
-      <%= paginate @posts %>
-    </div>
-    <div class="col-lg-3">
-      <div class="search-form">
-        <div class="form-group row">
-          <%= search_form_for @q do |f| %>
-            <%= f.search_field :content_cont, class: "form-control", placeholder: "内容を検索する" %>
-            <%= f.submit "検索", class: "btn btn-primary btn-twitter" %>
-          <% end %>
+    <div class="col-lg-3"></div>
+      <div class="col-lg-6 mb-lg-5">
+        <%= paginate @posts %>
+        <%= link_to "つぶやく", new_post_path, class: "btn btn-primary btn-lg btn-block btn-twitter" %>
+        <%= render @posts %>
+        <%= paginate @posts %>
+      </div>
+      <div class="col-lg-3">
+        <div class="search-form">
+          <div class="form-group row">
+            <%= search_form_for @q do |f| %>
+              <%= f.search_field :content_cont, class: "form-control", placeholder: "内容を検索する" %>
+              <%= f.submit "検索", class: "btn btn-primary btn-twitter" %>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="row">
-  <div class="col-lg-3"></div>
+    <div class="col-lg-3"></div>
     <div class="col-lg-6">
       <%= link_to "コメントする", new_post_comments_path(@post), class: "btn btn-primary btn-lg btn-block btn-twitter" %>
       <div class="post-detail-content">
@@ -71,5 +71,6 @@
         </div>
       <% end %>
       <%= link_to("戻る", posts_path,  class: "btn btn-secondary btn-lg btn-block btn-back") %>
+    </div>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -11,7 +11,7 @@
             <th width= 10% class="text-center"></th>
           </tr>
         </thead>
-        <tbody>          
+        <tbody>
           <% rank_status = 1 %>
           <% before_user_continue_day = 0 %>
           <% @rank_info.each.with_index(1) do |rank, i| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,6 @@ Rails.application.routes.draw do
     resource :comments, only: [:new, :create]
     resources :comments, only: [:edit, :update, :destroy]
   end
+
+  resources :informations, only: [:index, :show]
 end

--- a/db/migrate/20210704084926_create_information.rb
+++ b/db/migrate/20210704084926_create_information.rb
@@ -1,0 +1,11 @@
+class CreateInformation < ActiveRecord::Migration[6.1]
+  def change
+    create_table :information do |t|
+      t.string :title, null: false
+      t.text :content, null: false
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_13_072559) do
+ActiveRecord::Schema.define(version: 2021_07_04_084926) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,14 @@ ActiveRecord::Schema.define(version: 2021_06_13_072559) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "information", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "content", null: false
+    t.string "image"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "likes", force: :cascade do |t|

--- a/spec/factories/information.rb
+++ b/spec/factories/information.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :information do
+    title { "MyString" }
+    content { "MyText" }
+    image { "MyString" }
+  end
+end

--- a/spec/models/information_spec.rb
+++ b/spec/models/information_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Information, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/informations_spec.rb
+++ b/spec/requests/informations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Informations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
close #76 

## 実装内容

- ニュースを格納するテーブル定義は以下を元に作成する。なお、contentカラムはNot Null制約をつける
https://app.diagrams.net/#G1ZB5Aj0QXWD8xp9Vqr88tM-nYHzOtRmOS
- コントローラーではニューステーブルに格納されているcontentカラムの情報を全て出力させて、ビューに表示させる
- ログイン後のナビゲーションにニュースを閲覧するためのリンクを追加する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## 備考

- ニュースを格納するテーブルにタイトルおよび画像に関するカラムを追加