### PR TITLE
RailsアプリへのMarkdownの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ gem 'kaminari'
 # 検索機能
 gem 'ransack'
 
+# マークダウン記法の文字列をHTMLに変換
+gem 'redcarpet'
+
 group :development, :test do
   # Rails用のテストフレームワーク
   gem 'rspec-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem 'ransack'
 # マークダウン記法の文字列をHTMLに変換
 gem 'redcarpet'
 
+# シンタックスハイライト
+gem 'rouge'
+
 group :development, :test do
   # Rails用のテストフレームワーク
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -324,6 +325,7 @@ DEPENDENCIES
   rails (~> 6.1.3, >= 6.1.3.1)
   rails-i18n (~> 6.0)
   ransack
+  redcarpet
   rspec-rails
   sass-rails (>= 6)
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,6 +233,7 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rouge (3.26.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -326,6 +327,7 @@ DEPENDENCIES
   rails-i18n (~> 6.0)
   ransack
   redcarpet
+  rouge
   rspec-rails
   sass-rails (>= 6)
   spring

--- a/app/assets/stylesheets/_rouge.scss.erb
+++ b/app/assets/stylesheets/_rouge.scss.erb
@@ -1,0 +1,102 @@
+<%= Rouge::Themes::Magritte.render(scope: '.highlight') %> 
+
+pre.highlight {
+    overflow: auto;
+    word-wrap: normal;
+    white-space: pre;
+    background-color: #f6ffff;
+    padding: 0.5rem;
+    margin: 0;
+    border: 2px dashed #d6dddd;
+}
+
+div.highlight {
+    margin-top: 10px;
+    margin-bottom: 40px;
+}
+
+.highlight {
+    background-color: #f8f8f8;
+    .err, .nt {
+    color: #999999;
+    font-weight: bold;
+    background-color: #f6ffff;
+    }
+    .na {
+    color: #212529;
+    }
+    .vi, .mi, .no {
+    color: #008080;
+    font-weight: normal;
+    }
+    .s1, .s2, .sh, .si {
+    color: #d14;
+    font-weight: normal;
+    }
+    .nc {
+    color: #445588;
+    font-weight: bold;
+    }
+    .nf {
+    color: #990000;
+    font-weight: bold;
+    }
+    .nb {
+    color: #0086B3;
+    font-weight: normal;
+    }
+    .o, .kp {
+    color: #000000;
+    }
+    .mf, .mi {
+    color: #009999;
+    }
+    .ss {
+    color: #990073;
+    }
+    .c {
+    color: #999988;
+    }
+}
+
+.ruby {
+    .err {
+    color: #a61717;
+    }
+    .c1 {
+    color: #999988;
+    }
+}
+
+.markdown {
+    li a {
+    color: #e83e8c;
+    } 
+    thead {
+    background-color: #EEFFFF;
+    display: table-header-group;
+    ertical-align: middle;
+    width: 100%;
+    }
+    table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+    color: #212529;
+    border-spacing: 2px;
+    display: block;
+    overflow-x: scroll;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    }
+    th,td {
+    border: 1px solid #dee2e6;
+    padding: 0.75rem;
+    display: table-cell;
+    border-bottom-width: 2px;
+    white-space: nowrap;
+    }
+    tbody tr:nth-child(odd) {
+    background-color: rgba(0,0,0,0.05);
+    }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import "users";
 @import "bootstrap/scss/bootstrap";
 @import "font-awesome";
+@import 'rouge';
 
 // ナビバー
 .drawer-hamburger-icon,

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,26 @@
+module MarkdownHelper
+  def markdown(text)
+    markdown = Redcarpet::Markdown.new(html_renderer, markdown_extensions)
+    markdown.render(text).html_safe
+  end
+
+  private
+
+  def html_renderer
+    Redcarpet::Render::HTML
+  end
+
+  def markdown_extensions
+    {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true
+    }
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,3 +1,8 @@
+require 'rouge/plugins/redcarpet'
+class HTML < Redcarpet::Render::HTML
+  include Rouge::Plugins::Redcarpet
+end
+
 module MarkdownHelper
   def markdown(text)
     markdown = Redcarpet::Markdown.new(html_renderer, markdown_extensions)
@@ -7,7 +12,7 @@ module MarkdownHelper
   private
 
   def html_renderer
-    Redcarpet::Render::HTML
+    HTML.new(url_options)
   end
 
   def markdown_extensions

--- a/app/views/informations/show.html.erb
+++ b/app/views/informations/show.html.erb
@@ -1,8 +1,8 @@
 <div class="container">
   <div class="row">
     <div class="col-lg-3"></div>
-    <div class="col-lg-6">
-      <%= @information.content %>
+    <div class="col-lg-6 my-lg-5">
+      <%= markdown(@information.content) %>
       <%= link_to("戻る", informations_path,  class: "btn btn-secondary btn-lg btn-block btn-back") %>
     </div>
   </div>

--- a/app/views/informations/show.html.erb
+++ b/app/views/informations/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
-    <div class="col-lg-3"></div>
-    <div class="col-lg-6 my-lg-5">
+    <div class="col-lg-2"></div>
+    <div class="col-lg-8 my-lg-5">
       <%= markdown(@information.content) %>
       <%= link_to("戻る", informations_path,  class: "btn btn-secondary btn-lg btn-block btn-back") %>
     </div>


### PR DESCRIPTION
close #80 

## 実装内容

ニュース記事をMarkdown形式で記述できるようにする
- マークダウン形式をHTMLに変換するため、gem「Redcarpet」を導入する
- コードブロック で シンタックスハイライト が使用できるようにするために、gem「Rouge」を導入する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
