### PR TITLE
モデルスペック・リクエストスペックの実装

### DIFF
--- a/app/controllers/informations_controller.rb
+++ b/app/controllers/informations_controller.rb
@@ -1,4 +1,6 @@
 class InformationsController < ApplicationController
+  before_action :authenticate_user!
+  
   def index
     @informations = Information.all.order(created_at: :desc)
   end

--- a/spec/factories/information.rb
+++ b/spec/factories/information.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :information do
-    title { "MyString" }
-    content { "MyText" }
-    image { "MyString" }
+    title { Faker::Lorem.paragraph }
+    content { Faker::Lorem.paragraph }
   end
 end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe AdminUser, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -3,25 +3,25 @@ require 'rails_helper'
 RSpec.describe Comment, type: :model do
   describe "バリデーション" do
     subject { comment.valid? }
-      context "データが条件を満たすとき" do
-        let(:comment) { build(:comment) }
-        it "保存できる" do
-          expect(subject).to eq true
-        end
+    context "データが条件を満たすとき" do
+      let(:comment) { build(:comment) }
+      it "保存できる" do
+        expect(subject).to eq true
       end
-      context "content が空のとき" do
-        let(:comment) { build(:comment, content: "") }
-        it "エラーが発生する" do
-          expect(subject).to eq false
-          expect(comment.errors.messages[:content]).to include "を入力してください"
-        end
+    end
+    context "content が空のとき" do
+      let(:comment) { build(:comment, content: "") }
+      it "エラーが発生する" do
+        expect(subject).to eq false
+        expect(comment.errors.messages[:content]).to include "を入力してください"
       end
-      context "content  が141文字以上のとき" do
-        let(:comment) { build(:comment, content: "a" * 141) }
-        it "エラーが発生する" do
-          expect(subject).to eq false
-          expect(comment.errors.messages[:content]).to include "は140文字以内で入力してください"
-        end
+    end
+    context "content  が141文字以上のとき" do
+      let(:comment) { build(:comment, content: "a" * 141) }
+      it "エラーが発生する" do
+        expect(subject).to eq false
+        expect(comment.errors.messages[:content]).to include "は140文字以内で入力してください"
       end
+    end
   end
 end

--- a/spec/models/information_spec.rb
+++ b/spec/models/information_spec.rb
@@ -1,5 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe Information, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "バリデーション" do
+    subject { information.valid? }
+    context "データが条件を満たすとき" do
+      let(:information) { build(:information) }
+      it "保存できる" do
+        expect(subject).to eq true
+      end
+    end
+    context "title が空のとき" do
+      let(:information) { build(:information, title: "") }
+      it "エラーが発生する" do
+        expect(subject).to eq false
+        expect(information.errors.messages[:title]).to include "を入力してください"
+      end
+    end
+    context "content が空のとき" do
+      let(:information) { build(:information, content: "") }
+      it "エラーが発生する" do
+        expect(subject).to eq false
+        expect(information.errors.messages[:content]).to include "を入力してください"
+      end
+    end
+  end
 end

--- a/spec/requests/informations_spec.rb
+++ b/spec/requests/informations_spec.rb
@@ -1,7 +1,57 @@
 require 'rails_helper'
 
 RSpec.describe "Informations", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe  "Logind" do
+    let(:user) { create(:user) }
+    before do
+      sign_in user
+    end
+
+    describe "GET #index" do
+      let(:information) { create(:information) }
+      subject { get(informations_path) }
+
+      context "ニュースが存在するとき" do
+        it "リクエストが成功する" do
+          subject
+          expect(response).to have_http_status(200)
+        end
+      end
+    end
+
+    describe "GET #show" do
+      subject { get(information_path(information_id)) }
+
+      context "ニュースが存在するとき" do
+        let(:information) { create(:information) }
+        let(:information_id) { information.id }
+
+        it "リクエストが成功する" do
+          subject
+          expect(response).to have_http_status(200)
+        end
+
+        it "information.content が表示されている" do
+          subject
+          expect(response.body).to include information.content
+        end
+      end
+    end
+  end
+
+  describe  "Not Logged in" do
+    describe "GET #index" do
+      subject { get(informations_path) }
+
+      it "リダイレクトが成功する" do
+        subject
+        expect(response).to have_http_status(302)
+      end
+
+      it "ログインページにリダイレクトされる" do
+        subject
+        expect(response).to redirect_to new_user_session_path
+      end
+    end   
   end
 end


### PR DESCRIPTION
close #84 

## 実装内容

- informationテーブルに対して、モデルスペックを実装する
- titleおよびcontentが空出ない時をテストする
- titleおよびcontentが空の時をテストする
- informationコントローラーのindex、showアクションに対して、リクエストスペックを実装する
- ユーザログインしていない場合のリクエストスペックを実装する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
