### PR TITLE
ニュース機能のレスポンシブ対応

### DIFF
--- a/app/views/informations/index.html.erb
+++ b/app/views/informations/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-lg-3"></div>
-      <div class="col-lg-7">
+      <div class="col-lg-7 mb-5">
         <%= render partial: 'information', collection: @informations %>
       </div>
     </div>

--- a/app/views/informations/show.html.erb
+++ b/app/views/informations/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-lg-2"></div>
-    <div class="col-lg-8 my-lg-5">
+    <div class="col-lg-8 my-lg-5 mb-5">
       <%= markdown(@information.content) %>
       <%= link_to("戻る", informations_path,  class: "btn btn-secondary btn-lg btn-block btn-back") %>
     </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,7 +17,7 @@
         </div>
         <li><%=link_to(" ホーム", root_path, class: "drawer-menu-item fa fa-home", 'aria-hidden': true)%></li> 
         <li><%=link_to(" マイページ", user_path(current_user), class: "drawer-menu-item fa fa-address-card", 'aria-hidden': true)%></li> 
-        <li><%=link_to(" ログアウト", destroy_user_session_path, method: :delete, class: "drawer-menu-item fa fa-sign-out-alt", 'aria-hidden': true)%></li> 
+        <li><%=link_to(" ログアウト", destroy_user_session_path, method: :delete, class: "drawer-menu-item fa fa-sign-out-alt", 'aria-hidden': true)%></li>
         <li><%=link_to(" つぶやき一覧", posts_path,  class: "drawer-menu-item fa fa-comment", 'aria-hidden': true)%></li> 
         <li><%=link_to(" ランキング", users_path,  class: "drawer-menu-item fa fa-trophy", 'aria-hidden': true)%></li> 
         <li><%=link_to(" ニュース一覧", informations_path,  class: "drawer-menu-item fa fa-newspaper", 'aria-hidden': true)%></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/iScroll/5.1.3/iscroll.min.js"></script>
     <%# drawer.js %>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/drawer/3.2.1/js/drawer.min.js"></script>
-    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.3/css/all.css" integrity="sha384-SZXxX4whJ79/gErwcOYf+zWLeJdY/qpuqC4cAa9rOGUstPomtqpuNWT9wdPEn2fk" crossorigin="anonymous">
+    <link href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" rel="stylesheet">
   </head>
 
   <body class="drawer drawer--left" style="padding-top: 5rem">


### PR DESCRIPTION
close #91

## 実装内容

- スマホ画面でニュース機能の記事の詳細画面を見た際に、戻るボタンとページの一番下の間にスペースを空ける
- スマホ画面でニュース機能の索引を見た際に、ページの一番下の間にスペースを空ける

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
