### PR TITLE
いいね数およびコメント数のリファクタリング

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ApplicationRecord
   belongs_to :user
-  belongs_to :post, counter_cache: :comments_count
+  belongs_to :post
   validates :content, presence: true, length: { maximum: 140 }
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,6 +1,6 @@
 class Like < ApplicationRecord
   belongs_to :user
-  belongs_to :post, counter_cache: :likes_count
+  belongs_to :post
   validates :user_id, uniqueness: {
                       scope: :post_id,
                       message: "は同じ投稿に2回以上いいねはできません",

--- a/app/views/posts/_dislike.html.erb
+++ b/app/views/posts/_dislike.html.erb
@@ -1,2 +1,2 @@
 <%= link_to "", post_likes_path(post), class: "fa fa-heart fa-lg dislike-info", method: :post, remote: true %>
-<%= post.likes_count %>
+<%= post.likes.count %>

--- a/app/views/posts/_like.html.erb
+++ b/app/views/posts/_like.html.erb
@@ -1,2 +1,2 @@
 <%= link_to "", post_likes_path(post), class: "fa fa-heart fa-lg like-info", method: :delete, remote: true %>
-<%= post.likes_count %>
+<%= post.likes.count %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -35,6 +35,6 @@
   </div>
   <div class="comment-icon">
     <%= link_to "", post_path(post), class:"fa fa-comment fa-lg comment-style" %>
-    <%= post.comments_count %>
+    <%= post.comments.count %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -39,7 +39,7 @@
         </div>
         <div class="comment-icon">
           <span class="fa fa-comment fa-lg comment-style"></span>
-          <%= @post.comments_count %>
+          <%= @post.comments.count %>
         </div>
       </div>
 

--- a/db/migrate/20210726113807_remove_likes_count_from_posts.rb
+++ b/db/migrate/20210726113807_remove_likes_count_from_posts.rb
@@ -1,0 +1,7 @@
+class RemoveLikesCountFromPosts < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :posts, :likes_count, :integer
+
+    remove_column :posts, :comments_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_22_125354) do
+ActiveRecord::Schema.define(version: 2021_07_26_113807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,14 @@ ActiveRecord::Schema.define(version: 2021_07_22_125354) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "information_bk", id: false, force: :cascade do |t|
+    t.bigint "id"
+    t.string "title"
+    t.text "content"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
+  end
+
   create_table "likes", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "post_id", null: false
@@ -73,8 +81,6 @@ ActiveRecord::Schema.define(version: 2021_07_22_125354) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "likes_count", default: 0
-    t.integer "comments_count", default: 0
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
close #95 

## 実装内容

いいね数およびコメント数の表示方法を変更する
- `post.comments.count`を使用して、コメント数を表示する
- `post.likes.count`を使用して、いいね数を表示する
- postsテーブルのカラム`likes_count`および`comments_count`を削除する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
