### PR TITLE
節約金額の計算ロジックの修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,12 +12,10 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
-    use_days = @user.calc_use_day
-    @save_money = @user.calc_save_money(use_days)
     @stop_eat_sweets_day = @user.calc_stop_day
-    use_days_month = @user.calc_use_day_month
-    @save_money_month = @user.calc_save_money(use_days_month)
+    @save_money = @user.calc_save_money(@stop_eat_sweets_day)
     @stop_eat_sweets_day_month = @user.calc_stop_day_month
+    @save_money_month = @user.calc_save_money(@stop_eat_sweets_day_month)
   end
 
   def update_eat_day

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,28 +12,24 @@ class User < ApplicationRecord
   
   mount_uploader :image, ImageUploader
 
-  def calc_use_day
-    (Date.current - self.created_at.to_date).to_i
-  end
-
-  def calc_save_money(use_days)
-    self.cost * use_days
-  end
-
+  # サービス利用開始日からお菓子を止めた日数を算出する
   def calc_stop_day
-    self.calc_use_day - self.eat_day
+    (Date.current - self.created_at.to_date).to_i - self.eat_day
   end
 
-  def calc_use_day_month
-    if Date.today.beginning_of_month >= self.created_at
-      (Date.today - Date.today.beginning_of_month).to_i
-    else
-      (Date.today - self.created_at.to_date).to_i
-    end
+  # お菓子を止めたことによる節約金額を算出する
+  def calc_save_money(stop_eat_sweets_day)
+    self.cost * stop_eat_sweets_day
   end
 
+  # 今月のお菓子を止めた日数を算出する
   def calc_stop_day_month
-    self.calc_use_day_month - self.eat_day_month
+    if Date.today.beginning_of_month >= self.created_at
+      start_date = Date.today.beginning_of_month
+    else
+      start_date = self.created_at.to_date
+    end
+    (Date.today - start_date).to_i  - self.eat_day_month
   end
 
   def self.guest

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,11 +24,12 @@ class User < ApplicationRecord
 
   # 今月のお菓子を止めた日数を算出する
   def calc_stop_day_month
-    if Date.today.beginning_of_month >= self.created_at
-      start_date = Date.today.beginning_of_month
+    start_date = if Date.today.beginning_of_month >= self.created_at
+      Date.today.beginning_of_month
     else
-      start_date = self.created_at.to_date
+      self.created_at.to_date
     end
+
     (Date.today - start_date).to_i  - self.eat_day_month
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,16 +61,16 @@ RSpec.describe User, type: :model do
   end
 
   describe "インスタンスメソッド" do
-    context "calc_use_day のデータが条件を満たすとき" do
-      let(:user) { build(:user, created_at: Date.current - 1) }
-      it "ユーザのサービス利用日数が想定通りになる" do
-          expect(user.calc_use_day).to eq 1
+    context "calc_save_money(use_days) のデータが条件を満たすとき" do
+      let(:user) { build(:user, cost: 500) }
+      it "お菓子を辞めたことによる節約金額が想定通りになる" do
+          expect(user.calc_save_money(2)).to eq 1000
       end
     end
     context "calc_save_money(use_days) のデータが条件を満たすとき" do
       let(:user) { build(:user, cost: 500) }
       it "お菓子を辞めたことによる節約金額が想定通りになる" do
-          expect(user.calc_save_money(2)).to eq 1000
+          expect(user.calc_save_money(1)).to eq 500
       end
     end
     context "calc_stop_day のデータが条件を満たすとき" do
@@ -79,28 +79,22 @@ RSpec.describe User, type: :model do
           expect(user.calc_stop_day).to eq 1
       end
     end
-    context "ユーザ登録した日が前月末の場合で、calc_use_day_month のデータが条件を満たすとき" do
-      let(:user) { build(:user, created_at: Date.today.beginning_of_month - 1) }
-      it "ユーザの月のサービス利用日数が想定通りになる" do
-        expect(user.calc_use_day_month).to eq (Date.today - Date.today.beginning_of_month).to_i
-      end
-    end
-    context "ユーザ登録した日が月初1日の場合で、calc_use_day_month のデータが条件を満たすとき" do
-      let(:user) { build(:user, created_at: Date.today.beginning_of_month) }
-      it "ユーザの月のサービス利用日数が想定通りになる" do
-        expect(user.calc_use_day_month).to eq (Date.today - Date.today.beginning_of_month).to_i
-      end
-    end
-    context "ユーザ登録した日が月初2日の場合で、calc_use_day_month のデータが条件を満たすとき" do
-      let(:user) { build(:user, created_at: Date.today.beginning_of_month + 1) }
-      it "ユーザの月のサービス利用日数が想定通りになる" do
-        expect(user.calc_use_day_month).to eq (Date.today - user.created_at.to_date).to_i
-      end
-    end
-    context "calc_stop_day_month のデータが条件を満たすとき" do
+    context "ユーザ登録した日が前月末の場合で、calc_stop_day_month のデータが条件を満たすとき" do
       let(:user) { build(:user, created_at: Date.today.beginning_of_month - 1, eat_day_month:1) }
       it "お菓子を辞めた合計日数から食べてしまった日数を差し引いた日数が想定通りになる" do
           expect(user.calc_stop_day_month).to eq (Date.today - Date.today.beginning_of_month - 1).to_i
+      end
+    end
+    context "ユーザ登録した日が月初1日の場合で、calc_stop_day_month のデータが条件を満たすとき" do
+      let(:user) { build(:user, created_at: Date.today.beginning_of_month, eat_day_month:1) }
+      it "お菓子を辞めた合計日数から食べてしまった日数を差し引いた日数が想定通りになる" do
+          expect(user.calc_stop_day_month).to eq (Date.today - Date.today.beginning_of_month - 1).to_i
+      end
+    end
+    context "ユーザ登録した日が月初2日の場合で、calc_stop_day_month のデータが条件を満たすとき" do
+      let(:user) { build(:user, created_at: Date.today.beginning_of_month + 1, eat_day_month:1) }
+      it "お菓子を辞めた合計日数から食べてしまった日数を差し引いた日数が想定通りになる" do
+          expect(user.calc_stop_day_month).to eq (Date.today - user.created_at.to_date - 1).to_i
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,12 +67,6 @@ RSpec.describe User, type: :model do
           expect(user.calc_save_money(2)).to eq 1000
       end
     end
-    context "calc_save_money(use_days) のデータが条件を満たすとき" do
-      let(:user) { build(:user, cost: 500) }
-      it "お菓子を辞めたことによる節約金額が想定通りになる" do
-          expect(user.calc_save_money(1)).to eq 500
-      end
-    end
     context "calc_stop_day のデータが条件を満たすとき" do
       let(:user) { build(:user, created_at: Date.current - 2, eat_day:1) }
       it "お菓子を辞めた合計日数から食べてしまった日数を差し引いた日数が想定通りになる" do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Users", type: :request do
 
         it "save_money が表示されている" do
           subject
-          expect(response.body).to include user.calc_save_money(user.calc_use_day).to_s
+          expect(response.body).to include user.calc_save_money(user.calc_stop_day).to_s
         end
 
         it "stop_eat_sweets_day_month が表示されている" do
@@ -70,7 +70,7 @@ RSpec.describe "Users", type: :request do
 
         it "save_money_month が表示されている" do
           subject
-          expect(response.body).to include user.calc_save_money(user.calc_use_day_month).to_s
+          expect(response.body).to include user.calc_save_money(user.calc_stop_day_month).to_s
         end
       end
 


### PR DESCRIPTION
close #97 

## 実装内容

サービス利用開始から現在および1ヶ月間の節約金額を計算ロジックを修正する
- サービス利用開始から現在までの期間に一日あたりのお菓子に費やしていた金額を掛けていたが、
サービス利用開始から現在までの期間からお菓子を食べてしまった日数を引いた期間に一日あたりのお菓子に費やしていた金額を掛けるように修正する
- 1ヶ月間あたりの節約金額の計算ロジックについても上記と同様に修正する
- 上記の変更に伴い、Rspecも修正する
- 
## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
