### PR TITLE
お菓子を食べた件数をリセットする機能を実装

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!, :delete_eat_day_month
+  before_action :authenticate_user!
 
   def index
     users = User.all
@@ -27,14 +27,5 @@ class UsersController < ApplicationController
       flash[:alert] = "本日はこれ以上、申告できません"
     end
     redirect_back(fallback_location: user_path(@user))
-  end
-
-  private
-
-  def delete_eat_day_month
-    if Date.today == Date.today.beginning_of_month
-      @user = User.find(params[:id])
-      @user.update!(eat_day_month: 0)
-    end
   end
 end

--- a/lib/tasks/reset_eat_day_month.rake
+++ b/lib/tasks/reset_eat_day_month.rake
@@ -1,6 +1,6 @@
 namespace :reset_eat_day_month do
   desc "usersテーブルのeat_day_monthをリセットする"
-  task reset: :environment do
+  task reset_eat_day: :environment do
     begin
       user = User.all
       user.update(eat_day_month: 0)

--- a/lib/tasks/reset_eat_day_month.rake
+++ b/lib/tasks/reset_eat_day_month.rake
@@ -1,0 +1,18 @@
+namespace :reset_eat_day_month do
+  desc "usersテーブルのeat_day_monthをリセットする"
+  task reset: :environment do
+    begin
+      user = User.all
+      user.update(eat_day_month: 0)
+      puts "リセット完了"
+    rescue StandardError => e
+      # 例外が発生した場合の処理
+      # リセットできなかった場合の例外処理
+      puts "#{e.class}: #{e.message}"
+      puts "-------------------------"
+      puts e.backtrace # 例外が発生した位置情報
+      puts "-------------------------"
+      puts "リセットに失敗"
+    end
+  end
+end


### PR DESCRIPTION
close #99 

## 実装内容

1ヶ月に1回全ユーザーのお菓子を食べた件数を0件にする
- usersテーブルのeat_day_monthを0に更新するRakeタスクを実装
- 月の初めの0:00に上記で実装したRakeタスクが稼働するようにHerokuのスケジュールを設定する
 
## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
