### PR TITLE
トップページにてゲストログイン後の遷移先を変更

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -2,7 +2,7 @@ class Users::SessionsController < Devise::SessionsController
   def guest_sign_in
     # ゲストアカウントでログイン
     sign_in User.guest
-    # トップページへリダイレクト
-    redirect_to root_path, notice: "ゲストユーザーとしてログインしました。"
+    # マイページへリダイレクト
+    redirect_to user_path(current_user), notice: "ゲストユーザーとしてログインしました。"
   end
 end


### PR DESCRIPTION
close #105 

### 実装内容

- ゲストログインボタンを押下後、トップページへ遷移していた仕様を変更。
ゲストログイン後、マイページへ遷移するように変更
- `sessions_controller.rb`のリダイレクト先をマイページに変更する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
