### PR TITLE
つぶやき画面の検索機能の仕様変更

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,6 +8,7 @@ class PostsController < ApplicationController
   def index
     @q = Post.ransack(params[:q])
     @posts = @q.result.includes(:user, :likes).order(created_at: "DESC").page(params[:page]).per(PER_PAGE)
+    flash.now[:alert] = "検索に一致するつぶやきはありませんでした" if @posts.empty?
   end
 
   def new

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -11,7 +11,7 @@
         <div class="search-form">
           <div class="form-group row">
             <%= search_form_for @q do |f| %>
-              <%= f.search_field :content_cont, class: "form-control", placeholder: "内容を検索する" %>
+              <%= f.search_field :content_cont, class: "form-control", placeholder: "内容を検索する", required: true %>
               <%= f.submit "検索", class: "btn btn-primary btn-twitter" %>
             <% end %>
           </div>


### PR DESCRIPTION
close #107 

### 実装内容

- つぶやき画面の検索バーがブランクの場合、検索ワードを入力するようにユーザに促す
- 検索ワードにヒットしない場合、ヒットしたつぶやきがないことをメッセージ出力する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
