### PR TITLE
アカウント登録画面およびログイン画面にゲストログインボタンを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,7 +25,7 @@ $sub-color-fourth: #000000;
   background-color: $sub-color;
   border: none;
   text-align: center;
-  margin: 15px 15px 5px auto;
+  margin: 15px 15px 15px auto;
   box-shadow: 0 2px 2px 0 $sub-color-fourth
 }
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -17,15 +17,6 @@
               <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control', required: true %>
             </div>
 
-            <% if devise_mapping.rememberable? %>
-              <div class="form-group form-check">
-                <%= f.check_box :remember_me, class: 'form-check-input' %>
-                <%= f.label :remember_me, class: 'form-check-label' do %>
-                  <%= resource.class.human_attribute_name('remember_me') %>
-                <% end %>
-              </div>
-            <% end %>
-
             <div class="actions">
               <%= f.submit  t('.sign_in'), class: 'btn btn-info btn-lg btn-block' %>
             </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,4 +1,8 @@
 <div class="form-group">
+  <%- if controller_name != 'sessions' || devise_mapping.registerable? && controller_name != 'registrations' %>
+    <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post %><br />
+  <% end -%>
+
   <%- if controller_name != 'sessions' %>
     <%= link_to "既にアカウントをお持ちの方はこちら", new_session_path(resource_name) %><br />
   <% end -%>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -11,7 +11,7 @@
         <div class="search-form">
           <div class="form-group row">
             <%= search_form_for @q do |f| %>
-              <%= f.search_field :content_cont, class: "form-control", placeholder: "内容を検索する", required: true %>
+              <%= f.search_field :content_cont, class: "form-control", placeholder: "内容を検索する" %>
               <%= f.submit "検索", class: "btn btn-primary btn-twitter" %>
             <% end %>
           </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -26,11 +26,12 @@
               <td class="align-middle user-name-diplays">
                 <% if rank[0].image? %>
                   <%= image_tag rank[0].image.url, class: "show-user-image rounded-circle" %>
-                  <strong><%= link_to rank[0].name, user_path(rank[0]), class:"link_under_none" %></strong>
                 <% else %>
                   <%= image_tag 'no-image.png', class: "show-user-image rounded-circle" %>
-                  <strong><%= link_to rank[0].name, user_path(rank[0]), class:"link_under_none" %></strong>
                 <% end %>
+                <div class="d-inline-block">
+                  <strong><%= link_to rank[0].name, user_path(rank[0]), class:"link_under_none align-middle"%></strong>
+                </div>
               </td>
               <td class="align-middle text-center rank-info-continue">
                 <%= rank[1] %>


### PR DESCRIPTION
close #111 

## 実装内容

- ユーザに気軽にアプリを使用していただくために、アカウント登録画面およびログイン画面にゲストログインボタンを追加

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## 備考

- ランキング機能のデザイン修正
- つぶやき機能の検索バーにブランクを入力できるように仕様変更