### PR TITLE
アカウント登録およびログイン後の遷移先を変更

### DIFF
--- a/app/assets/stylesheets/_navbar.scss
+++ b/app/assets/stylesheets/_navbar.scss
@@ -42,6 +42,7 @@ $sub-color-second: #FFF;
   margin: auto auto 10px 25px;
   font-size:18px;
   margin-top: 5px;
+  font-weight: 550;
 
   a {
   overflow: hidden;

--- a/app/assets/stylesheets/_top.scss
+++ b/app/assets/stylesheets/_top.scss
@@ -37,7 +37,7 @@ $sub-color-fourth: #000000;
   }
 
   .top-page-button {
-    width: 55% !important;
+    width: 45% !important;
     font-size: 20px !important;
     padding: 10px !important;
   }
@@ -88,7 +88,7 @@ $sub-color-fourth: #000000;
 }
 
 .top-page-style {
-  height: 750px;
+  height: 780px;
   padding-top:100px;
 }
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,6 +7,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
+  def after_sign_up_path_for(resource)
+    #アカウント登録後のリダイレクト先
+    user_path(resource)
+  end
+
   protected
   def update_resource(resource, params)
     resource.update_without_password(params)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,6 +12,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
     user_path(resource)
   end
 
+  def after_update_path_for(resource)
+    #アカウント登録後のリダイレクト先
+    user_path(resource)
+  end
+
   protected
   def update_resource(resource, params)
     resource.update_without_password(params)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -5,4 +5,9 @@ class Users::SessionsController < Devise::SessionsController
     # マイページへリダイレクト
     redirect_to user_path(current_user), notice: "ゲストユーザーとしてログインしました。"
   end
+
+  def after_sign_in_path_for(resource)
+    #ログイン後のリダイレクト先
+    user_path(resource)
+  end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="row justify-content-center">
+  <div class="row justify-content-center mb-3">
     <div class="col-md-6">
       <div class="form-style">
         <div class="form-title">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,8 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users, controllers: {
     registrations: "users/registrations",
-    passwords: "users/passwords"
+    passwords: "users/passwords",
+    sessions: 'users/sessions'
   }
 
   root to: 'tops#index'


### PR DESCRIPTION
close #113 

## 実装内容

アカウント登録およびログイン後の遷移先がトップページのため、マイページに変更する
- `app/controllers/users/registrations_controller.rb`および`app/controllers/users/sessions_controller.rb`にマイページへの遷移先を定義する
- `config/routes.rb`に`sessions: 'users/sessions'`を追加する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## 備考

- トップページおよびマイページ編集画面のレスポンシブ対応