### PR TITLE
本番環境における画像の保存場所をAWS上とする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem 'activeadmin'
 # ログイン機能
 gem 'devise'
 
+# AmazonS3を使用
+gem 'fog-aws'
+
 # 多言語対応
 gem 'rails-i18n', '~> 6.0'
 gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
       devise (>= 4.7.1)
     diff-lcs (1.4.4)
     erubi (1.10.0)
+    excon (0.82.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -109,8 +110,25 @@ GEM
     faker (2.17.0)
       i18n (>= 1.6, < 2)
     ffi (1.15.0)
+    fog-aws (3.10.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.2.4)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-rails (4.7.0.7)
       railties (>= 3.2, < 7)
+    formatador (0.2.5)
     formtastic (4.0.0)
       actionpack (>= 5.2.0)
     formtastic_i18n (0.6.0)
@@ -129,6 +147,7 @@ GEM
       has_scope (~> 0.6)
       railties (>= 5.2, < 6.2)
       responders (>= 2, < 4)
+    ipaddress (0.8.3)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     jquery-rails (4.4.0)
@@ -157,11 +176,15 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
     mini_magick (4.11.0)
     mini_mime (1.0.3)
     mini_portile2 (2.5.1)
     minitest (5.14.4)
     msgpack (1.4.2)
+    multi_json (1.15.0)
     nio4r (2.5.7)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
@@ -313,6 +336,7 @@ DEPENDENCIES
   devise-i18n
   factory_bot_rails
   faker
+  fog-aws
   font-awesome-rails
   jbuilder (~> 2.7)
   kaminari

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,7 +8,7 @@ class PostsController < ApplicationController
   def index
     @q = Post.ransack(params[:q])
     @posts = @q.result.includes(:user, :likes).order(created_at: "DESC").page(params[:page]).per(PER_PAGE)
-    flash.now[:alert] = "検索に一致するつぶやきはありませんでした" if @posts.empty?
+    flash.now[:alert] = "検索に一致するつぶやきはありませんでした" if @posts.empty? && params[:q].present?
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,7 +8,11 @@ class PostsController < ApplicationController
   def index
     @q = Post.ransack(params[:q])
     @posts = @q.result.includes(:user, :likes).order(created_at: "DESC").page(params[:page]).per(PER_PAGE)
-    flash.now[:alert] = "検索に一致するつぶやきはありませんでした" if @posts.empty? && params[:q].present?
+    # つぶやきが1件も投稿されていなかった場合につぶやき一覧以外のページから遷移された際にメッセージが出力されることを防ぐ
+    if request.referer&.include?("posts")
+      # 検索バーにキーワードが入力されている状態かつ検索結果がなかった場合にメッセージを出力させる
+      flash.now[:alert] = "検索に一致するつぶやきはありませんでした" if @posts.empty? && params[:q][:content_cont].present?
+    end
   end
 
   def new

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,7 +2,11 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   include CarrierWave::MiniMagick
 
-  storage :file
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
 
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -1,0 +1,11 @@
+if Rails.env.production?
+  CarrierWave.configure do |config|
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['S3_ACCESS_KEY'],
+      aws_secret_access_key: ENV['S3_SECRET_KEY'],
+      region: ENV['S3_REGION']
+    }
+    config.fog_directory = ENV['S3_BUCKET']
+  end
+end

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -7,5 +7,6 @@ if Rails.env.production?
       region: ENV['S3_REGION']
     }
     config.fog_directory = ENV['S3_BUCKET']
+    config.asset_host = "https://dbt8gbc6r3u7.cloudfront.net"
   end
 end


### PR DESCRIPTION
close #115 

## 実装内容

- 本番環境における画像の保存場所をAWSのS3上とする
- アプリ用のIAMユーザーを作成し、アプリに与える権限は`AmazonS3FullAccess`とする
- CloudFront を用いて画像の表示を高速化する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## 備考

- つぶやき一覧の検索機能に関する仕様を変更。検索バーにキーワードが入力されている状態かつ検索結果が０件の場合にメッセージを出力させる