### PR TITLE
ニュース一覧をページネーション化

### DIFF
--- a/app/controllers/informations_controller.rb
+++ b/app/controllers/informations_controller.rb
@@ -1,8 +1,11 @@
 class InformationsController < ApplicationController
   before_action :authenticate_user!
-  
+
+  # 1ページの表示数
+  PER_PAGE = 5
+
   def index
-    @informations = Information.all.order(created_at: :desc)
+    @informations = Information.order(created_at: :desc).page(params[:page]).per(PER_PAGE)
   end
 
   def show

--- a/app/views/informations/index.html.erb
+++ b/app/views/informations/index.html.erb
@@ -2,7 +2,9 @@
   <div class="row">
     <div class="col-lg-3"></div>
       <div class="col-lg-7 mb-5">
+        <%= paginate @informations %>
         <%= render partial: 'information', collection: @informations %>
+        <%= paginate @informations %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
close #121 

## 実装内容

- 今後、ニュース記事が増加したことにより、ブラウザの表示速度が遅くなってしまうため、ページネーションを導入する
- 1ページあたり5つのタイトルまで表示する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
