### PR TITLE
つぶやき機能のN+1問題の解消

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,7 +7,7 @@ class PostsController < ApplicationController
 
   def index
     @q = Post.ransack(params[:q])
-    @posts = @q.result.includes(:user, :likes).order(created_at: "DESC").page(params[:page]).per(PER_PAGE)
+    @posts = @q.result.includes(:user, :likes, :comments).order(created_at: "DESC").page(params[:page]).per(PER_PAGE)
     # つぶやきが1件も投稿されていなかった場合につぶやき一覧以外のページから遷移された際にメッセージが出力されることを防ぐ
     if request.referer&.include?("posts")
       # 検索バーにキーワードが入力されている状態かつ検索結果がなかった場合にメッセージを出力させる

--- a/app/views/posts/_dislike.html.erb
+++ b/app/views/posts/_dislike.html.erb
@@ -1,2 +1,2 @@
 <%= link_to "", post_likes_path(post), class: "fa fa-heart fa-lg dislike-info", method: :post, remote: true %>
-<%= post.likes.count %>
+<%= post.likes.size %>

--- a/app/views/posts/_like.html.erb
+++ b/app/views/posts/_like.html.erb
@@ -1,2 +1,2 @@
 <%= link_to "", post_likes_path(post), class: "fa fa-heart fa-lg like-info", method: :delete, remote: true %>
-<%= post.likes.count %>
+<%= post.likes.size %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -35,6 +35,6 @@
   </div>
   <div class="comment-icon">
     <%= link_to "", post_path(post), class:"fa fa-comment fa-lg comment-style" %>
-    <%= post.comments.count %>
+    <%= post.comments.size %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class="col-lg-3"></div>
-    <div class="col-lg-6">
+    <div class="col-lg-6 mb-5">
       <%= link_to "コメントする", new_post_comments_path(@post), class: "btn btn-primary btn-lg btn-block btn-twitter" %>
       <div class="post-detail-content">
         <% if @post.user.image? %>
@@ -70,7 +70,7 @@
           </div>
         </div>
       <% end %>
-      <%= link_to("戻る", posts_path,  class: "btn btn-secondary btn-lg btn-block btn-back") %>
+      <%= link_to("戻る", posts_path,  class: "btn btn-secondary btn-lg btn-block btn-back mt-4") %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
close #123 

## 実装内容

つぶやき機能にて、投稿に対するコメント数およびいいね数を表示する際にN+1問題が発生しているため、解消する
- コメント数およびいいね数を表示する際にcountを使用しているため、sizeに変更する
- posts_controller.rbのindexアクションにて、includesメソッドの中にcommentsを追加することで、事前にcommentsモデルの情報を取得する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
