### PR TITLE
N+1問題が発生していないかをチェック

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,8 @@ gem 'redcarpet'
 # シンタックスハイライト
 gem 'rouge'
 
+gem 'counter_culture'
+
 group :development, :test do
   # Rails用のテストフレームワーク
   gem 'rspec-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'pry-byebug'
   gem 'pry-doc'
+  gem 'bullet'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,9 @@ GEM
       ssrf_filter (~> 1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
+    counter_culture (2.9.0)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
     crass (1.0.6)
     devise (4.7.3)
       bcrypt (~> 3.0)
@@ -332,6 +335,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   carrierwave (~> 2.0)
+  counter_culture
   devise
   devise-i18n
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,9 @@ GEM
     bootsnap (1.7.3)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.5)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     carrierwave (2.2.1)
       activemodel (>= 5.0.0)
@@ -307,6 +310,7 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    uniform_notifier (1.14.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -333,6 +337,7 @@ PLATFORMS
 DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.4)
+  bullet
   byebug
   carrierwave (~> 2.0)
   counter_culture

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,7 +7,7 @@ class PostsController < ApplicationController
 
   def index
     @q = Post.ransack(params[:q])
-    @posts = @q.result.includes(:user, :likes, :comments).order(created_at: "DESC").page(params[:page]).per(PER_PAGE)
+    @posts = @q.result.includes(:user, :likes).order(created_at: "DESC").page(params[:page]).per(PER_PAGE)
     # つぶやきが1件も投稿されていなかった場合につぶやき一覧以外のページから遷移された際にメッセージが出力されることを防ぐ
     if request.referer&.include?("posts")
       # 検索バーにキーワードが入力されている状態かつ検索結果がなかった場合にメッセージを出力させる

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
+  counter_culture :post
   validates :content, presence: true, length: { maximum: 140 }
 end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -35,6 +35,6 @@
   </div>
   <div class="comment-icon">
     <%= link_to "", post_path(post), class:"fa fa-comment fa-lg comment-style" %>
-    <%= post.comments.size %>
+    <%= post.comments_count %>
   </div>
 </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,16 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+  # Bullet.growl         = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   config.cache_classes = false
 
   config.eager_load = false

--- a/db/migrate/20210606020332_add_comments_count_to_posts.rb
+++ b/db/migrate/20210606020332_add_comments_count_to_posts.rb
@@ -1,5 +1,0 @@
-class AddCommentsCountToPosts < ActiveRecord::Migration[6.1]
-  def change
-    add_column :posts, :comments_count, :integer, default: 0
-  end
-end

--- a/db/migrate/20210828012327_add_comments_count_to_posts.rb
+++ b/db/migrate/20210828012327_add_comments_count_to_posts.rb
@@ -1,0 +1,9 @@
+class AddCommentsCountToPosts < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :posts, :comments_count, :integer, null: false, default: 0
+  end
+
+  def self.down
+    remove_column :posts, :comments_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,14 +58,6 @@ ActiveRecord::Schema.define(version: 2021_08_28_012327) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "information_bk", id: false, force: :cascade do |t|
-    t.bigint "id"
-    t.string "title"
-    t.text "content"
-    t.datetime "created_at", precision: 6
-    t.datetime "updated_at", precision: 6
-  end
-
   create_table "likes", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "post_id", null: false
@@ -83,14 +75,6 @@ ActiveRecord::Schema.define(version: 2021_08_28_012327) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "comments_count", default: 0, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
-  end
-
-  create_table "posts_bk", id: false, force: :cascade do |t|
-    t.bigint "id"
-    t.text "content"
-    t.bigint "user_id"
-    t.datetime "created_at", precision: 6
-    t.datetime "updated_at", precision: 6
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_26_113807) do
+ActiveRecord::Schema.define(version: 2021_08_28_012327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,7 +81,16 @@ ActiveRecord::Schema.define(version: 2021_07_26_113807) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "comments_count", default: 0, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "posts_bk", id: false, force: :cascade do |t|
+    t.bigint "id"
+    t.text "content"
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6
+    t.datetime "updated_at", precision: 6
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
close #125

## 実装内容

- 目視で確認した以外にN+1問題が発生していないかを確認するためにgem`bullet`をインストールする
- gem`bullet`を使用した結果、つぶやきに対するコメント数を取得する際にN+1が発生していたため、gem`counter_culture`をインストール後、postsテーブルにコメント数を数える`comments_count`を追加

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
