### PR TITLE
不要なマイグレーションファイルを削除

### DIFF
--- a/db/migrate/20210514065059_add_likes_count_to_posts.rb
+++ b/db/migrate/20210514065059_add_likes_count_to_posts.rb
@@ -1,5 +1,0 @@
-class AddLikesCountToPosts < ActiveRecord::Migration[6.1]
-  def change
-    add_column :posts, :likes_count, :integer, default: 0
-  end
-end

--- a/db/migrate/20210726113807_remove_likes_count_from_posts.rb
+++ b/db/migrate/20210726113807_remove_likes_count_from_posts.rb
@@ -1,7 +1,0 @@
-class RemoveLikesCountFromPosts < ActiveRecord::Migration[6.1]
-  def change
-    remove_column :posts, :likes_count, :integer
-
-    remove_column :posts, :comments_count, :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,7 +89,7 @@ ActiveRecord::Schema.define(version: 2021_08_28_012327) do
     t.integer "cost", default: 0
     t.string "image"
     t.integer "eat_day", default: 0
-    t.date "eat_day_updated_on", default: "2021-07-12", null: false
+    t.date "eat_day_updated_on", default: "2021-08-29", null: false
     t.integer "eat_day_month", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
close #129 

## 実装内容
- AWSにデプロイする際に、不要なマイグレーションファイルが存在していたことにより、エラーとなってしまうため、削除する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

