### PR TITLE
Feature/post design modification height

### DIFF
--- a/app/assets/stylesheets/_post.scss
+++ b/app/assets/stylesheets/_post.scss
@@ -41,7 +41,7 @@ $sub-color-fourth: #000000;
   margin: 0px auto;
   width: 60%;
   text-overflow: ellipsis;
-  height: 180px;
+  height: 170px;
 }
 
 .post-icon {
@@ -93,6 +93,11 @@ $sub-color-fourth: #000000;
   margin-right: 20px;
 }
 
+.tweet_content {
+  text-decoration: none;
+  color: $sub-color-fourth; 
+}
+
 @media only screen and (max-width:767px) {
   .dropdown-menu {
     min-width: 10px
@@ -123,7 +128,7 @@ table {
 
 .post-detail-content {
   border: dotted 1px silver;
-  height: 250px;
+  height: 350px;
   padding: 10px;
 }
 
@@ -153,11 +158,15 @@ table {
 
 @media only screen and (max-width:480px) {
   .post-content {
-    height: 510px;
+    height: 460px;
   }
 
   .content {
-    height: 340px;
-    width: 70%;
+    height: 280px;
+    width: 80%;
+  }
+
+  .post-detail-content {
+    height: 440px;
   }
 }

--- a/app/assets/stylesheets/_post.scss
+++ b/app/assets/stylesheets/_post.scss
@@ -22,7 +22,7 @@ $sub-color-fourth: #000000;
 
 .post-content {
   border: dotted 1px silver;
-  height: 250px;
+  height: 350px;
   margin-top: 10px;
   padding: 10px;
 }
@@ -41,7 +41,7 @@ $sub-color-fourth: #000000;
   margin: 0px auto;
   width: 60%;
   text-overflow: ellipsis;
-  height: 70px;
+  height: 180px;
 }
 
 .post-icon {
@@ -100,7 +100,7 @@ $sub-color-fourth: #000000;
 
   .user-name {
     font-size: 1.2em;
-  }
+  } 
 }
 
 table {
@@ -148,5 +148,16 @@ table {
   .search-form {
     margin-left: 15px;
     margin-top: 50px;
+  }
+}
+
+@media only screen and (max-width:480px) {
+  .post-content {
+    height: 510px;
+  }
+
+  .content {
+    height: 340px;
+    width: 70%;
   }
 }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -22,7 +22,7 @@
         <li><%=link_to(" ランキング", users_path,  class: "drawer-menu-item fa fa-trophy", 'aria-hidden': true)%></li> 
         <li><%=link_to(" ニュース一覧", informations_path,  class: "drawer-menu-item fa fa-newspaper", 'aria-hidden': true)%></li>
       <% else %>
-        <%# 非ログイン時 %>
+        <%# 未ログイン時 %>
         <div class="nav-header">
           <%=link_to("", new_user_session_path, class: "fa fa-user-circle menu-icon link_under_none_white", 'aria-hidden': true)%>
           <div class="nav-username">
@@ -37,7 +37,13 @@
     </ul>
   </nav>
   <ul class="navbar-nav ml-auto main-nav align-items-right">
-    <a class="nav navbar-brand font-weight-bold" href="/">Stop Sweets</a>
+  <% if user_signed_in? %>
+    <%# ログイン時 %>
+    <%=link_to("Stop Sweets", user_path(current_user), class: "nav navbar-brand font-weight-bold", 'aria-hidden': true)%>
+  <% else %>
+    <%# 未ログイン時 %>
+    <%=link_to("Stop Sweets", root_path, class: "nav navbar-brand font-weight-bold", 'aria-hidden': true)%>
+  <% end %> 
   </ul>
 </nav>
 

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,28 +1,26 @@
 <div class="post-content">
   <% if post.user.image? %>
-    <%= image_tag post.user.image.url, class: "show_image" %>
+    <%= link_to image_tag(post.user.image.url, class: "show_image"), post_path(post) %>
   <% else %>
-    <%= image_tag 'no-image.png', class: "show_image" %>
+    <%= link_to image_tag('no-image.png', class: "show_image"), post_path(post) %>
   <% end %>
 
   <strong class="user-name">
     <%= link_to post.user.name, user_path(post.user), class:"link_under_none" %>
   </strong>
   <div class="dropdown">
-    <button class="btn fa fa-ellipsis-v" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    </button>
-    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-      <%= link_to "詳細", post_path(post), class:"dropdown-item" %>
-      <% if current_user.id == post.user_id %>
-        <div class="dropdown-divider"></div>
+    <% if current_user.id == post.user_id %>
+      <button class="btn fa fa-ellipsis-v" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      </button>
+      <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
         <%= link_to "編集", edit_post_path(post), class:"dropdown-item" %>
         <div class="dropdown-divider"></div>
-        <%= link_to "削除", post_path(post), method: :delete, data: { confirm: "削除しますか？" }, class:"dropdown-item" %>
-      <% end %>
-    </div>
+        <%= link_to "削除", post_path(post), method: :delete, data: { confirm: "削除しますか？" }, class:"dropdown-item" %>        
+      </div>
+    <% end %>
   </div>
   <div class="content">
-    <p><%= post.content %></p>
+    <%= link_to post.content, post_path(post), class: "tweet_content" %>
   </div>
   <div class="post-icon">
     <span id="post-<%= post.id %>">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -15,7 +15,7 @@
       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
         <%= link_to "編集", edit_post_path(post), class:"dropdown-item" %>
         <div class="dropdown-divider"></div>
-        <%= link_to "削除", post_path(post), method: :delete, data: { confirm: "削除しますか？" }, class:"dropdown-item" %>        
+        <%= link_to "削除", post_path(post), method: :delete, data: { confirm: "削除しますか？" }, class:"dropdown-item" %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
close #138 

## 実装内容

つぶやき機能にて、文字数を多く入力することにより、レイアウトが崩れてしまうため、修正する。また、つぶやきの詳細を見る際に、詳細ボタンで遷移するのではなく、つぶやきセルをクリックすることにより遷移するようにする。
- PCおよびスマートフォンでつぶやき可能な文字数である140文字を入力してもレイアウトが崩れないように、「_post.scss」を修正する。
- つぶやきの詳細を見るための詳細ボタンを削除し、つぶやきセルをクリックすることでつぶやきの詳細画面に遷移するようにする。また、画像アイコンをクリックすることで、つぶやきの詳細を見れるようにする。

ヘッダーのロゴをクリックした際にログイン済みの場合とログイン未済の場合で遷移先を変更する
- ログイン未済の場合はトップページに遷移するようにする
- ログイン済みの場合はマイページに遷移するようにする

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
