### PR TITLE
つぶやき機能の修正およびエラーハンドリング

### DIFF
--- a/app/assets/stylesheets/_post.scss
+++ b/app/assets/stylesheets/_post.scss
@@ -98,6 +98,10 @@ $sub-color-fourth: #000000;
   color: $sub-color-fourth; 
 }
 
+.tweet_content:hover {
+  text-decoration: none;
+}
+
 @media only screen and (max-width:767px) {
   .dropdown-menu {
     min-width: 10px

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   protect_from_forgery with: :exception
+  rescue_from Exception, with: :render_500
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
   protected
 
@@ -9,5 +11,15 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :cost])
     # アカウント編集時のストロングパラメータ
     devise_parameter_sanitizer.permit(:account_update, keys: [:name, :image, :cost])
+  end
+
+  private
+
+  def render_500
+    render file: Rails.root.join('public/500.html'), status: 404, layout: false, content_type: 'text/html'
+  end
+
+  def render_404
+    render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html'
   end
 end

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -19,9 +19,11 @@
       </div>
     <% end %>
   </div>
-  <div class="content">
-    <%= link_to post.content, post_path(post), class: "tweet_content" %>
-  </div>
+  <%= link_to(post_path(post), class: "tweet_content") do %>
+    <div class="content">
+      <%= post.content %>
+    </div>
+  <% end %>
   <div class="post-icon">
     <span id="post-<%= post.id %>">
       <% if post.liked_by?(current_user) %>

--- a/public/404.html
+++ b/public/404.html
@@ -58,10 +58,10 @@
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+      <h1>お探しのページは見つかりませんでした(404)</h1>
+      <p>ご指定のURLを再度ご確認ください</p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p>トップページへは<a href="/">こちら</a>より戻れます</p>
   </div>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -58,9 +58,10 @@
   <!-- This file lives in public/500.html -->
   <div class="dialog">
     <div>
-      <h1>We're sorry, but something went wrong.</h1>
+      <h1>ページが表示できません</h1>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
+    <p>ご不便をおかけし申し訳ございません。<br>
+    正常にご覧いただけるよう、解決に取り組んでおります。</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
close #142

## 実装内容

- つぶやき機能にて、ユーザがつぶやいた内容のブロックを選択したら、詳細画面に遷移するように修正。現在はブロックではなく、つぶやいた文字を選択しないと画面遷移しないため
- つぶやきにカーソルを当てた際に下線が表示されないように修正
- 404エラーが発生した際に404.htmlファイルを表示するようにする。また、エラー画面は日本語で表示する
- 500エラーが発生した際に500.htmlファイルを表示するようにする。また、エラー画面は日本語で表示する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認