### PR TITLE
お菓子を止めた日数のランキングを表示するロジックをSQLで実装するように変更

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -12,29 +12,26 @@
           </tr>
         </thead>
         <tbody>
-          <% @rank_status = 1 %>
-          <% @before_user_continue_day = 0 %>
-          <% @rank_info.each.with_index(1) do |rank, i| %>
-            <% check_user_rank(rank, i, @before_user_continue_day, @rank_status) %>
+          <% @users.each do |user| %>
             <tr> 
               <td class="align-middle text-center rank-info">
-                <%= @rank_status %>
+                <%= user.rank %>
               </td>
               <td class="align-middle user-name-diplays">
-                <% if rank[0].image? %>
-                  <%= image_tag rank[0].image.url, class: "show-user-image rounded-circle" %>
+                <% if user.image? %>
+                  <%= image_tag user.image.url, class: "show-user-image rounded-circle" %>
                 <% else %>
                   <%= image_tag 'no-image.png', class: "show-user-image rounded-circle" %>
                 <% end %>
                 <div class="d-inline-block">
-                  <strong><%= link_to rank[0].name, user_path(rank[0]), class:"link_under_none align-middle"%></strong>
+                  <strong><%= link_to user.name, user_path(user.id), class:"link_under_none align-middle"%></strong>
                 </div>
               </td>
               <td class="align-middle text-center rank-info-continue">
-                <%= rank[1] %>
+                <%= user.stop_day %>
               </td>
               <td class="align-middle text-center">
-                <%= display_crown(@rank_status) %>
+                <%= display_crown(user.rank) %>
               </td>
             </tr>
           <% end %>


### PR DESCRIPTION
close #144

## 実装内容
- お菓子を止めた日数を表示するためのロジックをrubyで実装していたものをSQLのdense_rank関数を使用して、実装する
- ランキングに表示するユーザ数を100までとする。今後ユーザ数が増えたことにより、パフォーマンスが低下してしまうため

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
