### PR TITLE
Rspecの修正

### DIFF
--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -84,8 +84,9 @@ RSpec.describe "Comments", type: :request do
       context "idに対応するコメントが存在しないとき" do
         let(:comment_id) { 1 }
 
-        it "エラーが発生する" do
-          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        it "404.htmlが表示される" do
+          subject
+          expect(response.body).to include 'お探しのページは見つかりませんでした(404)'
         end
       end
     end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -127,8 +127,9 @@ RSpec.describe "Posts", type: :request do
       context "idに対応する投稿が存在しないとき" do
         let(:post_id) { 1 }
 
-        it "エラーが発生する" do
-          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        it "404.htmlが表示される" do
+          subject
+          expect(response.body).to include 'お探しのページは見つかりませんでした(404)'
         end
       end
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -77,8 +77,9 @@ RSpec.describe "Users", type: :request do
       context ":idに対応するユーザーが存在しないとき" do
         let(:user_id) { 1 }
 
-        it "エラーが発生する" do
-          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        it "404.htmlが表示される" do
+          subject
+          expect(response.body).to include 'お探しのページは見つかりませんでした(404)'
         end
       end
     end


### PR DESCRIPTION
close #151

## 実装内容

- 存在しないユーザID、つぶやき、コメントにアクセスした際に「ActiveRecord::RecordNotFound」が表示されるようにしていたが、404.htmlにリダイレクトするようにしたため、Rspecも変更する。

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
