### PR TITLE
ルーティングエラーが発生した際の例外処理

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,12 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   protect_from_forgery with: :exception
   rescue_from Exception, with: :render_500
-  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+  rescue_from ActiveRecord::RecordNotFound, ActionController::RoutingError, with: :render_404
 
+  def routing_error
+    raise ActionController::RoutingError, params[:path]
+  end
+  
   protected
 
   def configure_permitted_parameters
@@ -15,11 +19,13 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def render_500
-    render file: Rails.root.join('public/500.html'), status: 404, layout: false, content_type: 'text/html'
+  def render_404(e = nil)
+    logger.info "Rendering 404 with exception: #{e.message}" if e
+    render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html'
   end
 
-  def render_404
-    render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html'
+  def render_500(e = nil)
+    logger.error "Rendering 500 with exception: #{e.message}" if e
+    render file: Rails.root.join('public/500.html'), status: 500, layout: false, content_type: 'text/html'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,4 +24,5 @@ Rails.application.routes.draw do
   end
 
   resources :informations, only: [:index, :show]
+  match '*unmatched_route' => 'application#routing_error', via: :all
 end


### PR DESCRIPTION
close #156 

## 実装内容

- ルーティングエラーが発生した際に404.htmlを表示するようにする
- routes.rbにmatchメソッドを追加して、該当するパスをapplication_controllerのrender_404メソッドに遷移する

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
