### PR TITLE
境界値テストの追加

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe User, type: :model do
         expect(user.errors.messages[:name]).to include "を入力してください"
       end
     end
+    context "name が50文字のとき" do
+      let(:user) { build(:user, name: "a" * 50) }
+      it "保存できる" do
+        expect(subject).to eq true
+      end
+    end
     context "name が51文字以上のとき" do
       let(:user) { build(:user, name: "a" * 51) }
       it "エラーが発生する" do
@@ -30,8 +36,14 @@ RSpec.describe User, type: :model do
         expect(user.errors.messages[:email]).to include "を入力してください"
       end
     end
+    context "email が255文字のとき" do
+      let(:user) { build(:user, email: "a" * 243 + "@example.com") }
+      it "保存できる" do
+        expect(subject).to eq true
+      end
+    end
     context "email が256文字以上のとき" do
-      let(:user) { build(:user, email: "a" * 256) }
+      let(:user) { build(:user, email: "a" * 244 + "@example.com") }
       it "エラーが発生する" do
         expect(subject).to eq false
         expect(user.errors.messages[:email]).to include "は255文字以内で入力してください"


### PR DESCRIPTION
close #146

## 実装内容

- userモデルのテストケースとして境界値のチェックを追加する。例えば、「user_spec」にて、ユーザの名前が50文字以内のため、50文字のパターンでもチェックする

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
