### PR TITLE
お菓子を止めた日数の数えるタイミングを変更する

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,9 +12,12 @@ class User < ApplicationRecord
   
   mount_uploader :image, ImageUploader
 
+  # 当日中にお菓子を止めた日数をカウントする
+  COUNT_STOPDAY_TODAY = 1
+
   # サービス利用開始日からお菓子を止めた日数を算出する
   def calc_stop_day
-    (Date.current - self.created_at.to_date).to_i - self.eat_day
+    (Date.current - self.created_at.to_date).to_i + COUNT_STOPDAY_TODAY - self.eat_day
   end
 
   # サービス利用開始時からお菓子を止めたことによる節約金額を算出する
@@ -35,7 +38,7 @@ class User < ApplicationRecord
       self.created_at.to_date
     end
 
-    (Date.today - start_date).to_i  - self.eat_day_month
+    (Date.today - start_date).to_i  + COUNT_STOPDAY_TODAY - self.eat_day_month
   end
 
   def self.guest

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,32 +76,32 @@ RSpec.describe User, type: :model do
     context "save_money のデータが条件を満たすとき" do
       let(:user) { build(:user, cost: 500, created_at: Date.current - 2) }
       it "お菓子を辞めたことによる節約金額が想定通りになる" do
-          expect(user.save_money).to eq 1000
+          expect(user.save_money).to eq 1500
       end
     end
 
     context "calc_stop_day のデータが条件を満たすとき" do
       let(:user) { build(:user, created_at: Date.current - 2, eat_day:1) }
       it "お菓子を辞めた合計日数から食べてしまった日数を差し引いた日数が想定通りになる" do
-          expect(user.calc_stop_day).to eq 1
+          expect(user.calc_stop_day).to eq 2
       end
     end
     context "ユーザ登録した日が前月末の場合で、calc_stop_day_month のデータが条件を満たすとき" do
       let(:user) { build(:user, created_at: Date.today.beginning_of_month - 1, eat_day_month:1) }
       it "お菓子を辞めた合計日数から食べてしまった日数を差し引いた日数が想定通りになる" do
-          expect(user.calc_stop_day_month).to eq (Date.today - Date.today.beginning_of_month - 1).to_i
+          expect(user.calc_stop_day_month).to eq (Date.today - Date.today.beginning_of_month).to_i
       end
     end
     context "ユーザ登録した日が月初1日の場合で、calc_stop_day_month のデータが条件を満たすとき" do
       let(:user) { build(:user, created_at: Date.today.beginning_of_month, eat_day_month:1) }
       it "お菓子を辞めた合計日数から食べてしまった日数を差し引いた日数が想定通りになる" do
-          expect(user.calc_stop_day_month).to eq (Date.today - Date.today.beginning_of_month - 1).to_i
+          expect(user.calc_stop_day_month).to eq (Date.today - Date.today.beginning_of_month).to_i
       end
     end
     context "ユーザ登録した日が月初2日の場合で、calc_stop_day_month のデータが条件を満たすとき" do
       let(:user) { build(:user, created_at: Date.today.beginning_of_month + 1, eat_day_month:1) }
       it "お菓子を辞めた合計日数から食べてしまった日数を差し引いた日数が想定通りになる" do
-          expect(user.calc_stop_day_month).to eq (Date.today - user.created_at.to_date - 1).to_i
+          expect(user.calc_stop_day_month).to eq (Date.today - user.created_at.to_date).to_i
       end
     end
   end


### PR DESCRIPTION
close #165

## 実装内容

- 月初にお菓子を食べたことを申告した場合、月のお菓子を止めた日数がマイナスにならないようにする。
- お菓子を止めた日数の数えるタイミングを変更する。今までは初日にお菓子を止めた日数は0日として、2日目にお菓子を止めた日数を1日としていた。初日にお菓子を止めた日数を1日として、2日に2日と数えるようにする。
- 上記の変更に伴い、テストも変更する。

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
