### PR TITLE
マイページのボタン表示に関する修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
-  validates :name, presence: true, length: { maximum: 50 }
-  validates :email, length: { maximum: 255 }
+  before_save { self.email = self.email.downcase }
+  validates :name, presence: true, length: { maximum: 50 }, uniqueness: true
+  validates :email, length: { maximum: 255 }, uniqueness: true
   validates :cost, numericality: { greater_than_or_equal_to: 0, only_integer: true }
 
   has_many :posts, dependent: :destroy

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -52,7 +52,7 @@
           <th class="font-weight-normal change-color"><%= @user.save_money_month %>円</th>
         </tr>
       </table>
-      <% if current_user.id == @user.id %>
+      <% if current_user.id == @user.id && @user.name != "ゲストユーザ" %>
         <div class="mypage-button-info">
           <%=link_to("編集", edit_user_registration_path, class: "btn btn-info mypage-button")%>
           <%=link_to("削除", user_registration_path, method: :delete, class: "btn btn-info mypage-button", data: { confirm: '本当に削除しますか？' } )%>

--- a/db/migrate/20211218010913_add_index_to_users_name.rb
+++ b/db/migrate/20211218010913_add_index_to_users_name.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsersName < ActiveRecord::Migration[6.1]
+  def change
+    add_index :users, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_28_012327) do
+ActiveRecord::Schema.define(version: 2021_12_18_010913) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 2021_08_28_012327) do
     t.date "eat_day_updated_on", default: "2021-08-29", null: false
     t.integer "eat_day_month", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe User, type: :model do
         expect(user.errors.messages[:name]).to include "は50文字以内で入力してください"
       end
     end
+    context "name(両方が小文字) が重複するとき" do
+      let(:user) { build(:user, name: "hogehoge") }
+      it "エラーが発生する" do
+        create(:user, name: "hogehoge")
+        expect(subject).to eq false
+        expect(user.errors.messages[:name]).to include "はすでに存在します"
+      end
+    end
+    context "name(片方が大文字、片方が小文字) が重複するとき" do
+      let(:user) { build(:user, name: "HOGEHOGE") }
+      it "保存できる" do
+        create(:user, name: "hogehoge")
+        expect(subject).to eq true
+      end
+    end
     context "email が空のとき" do
       let(:user) { build(:user, email: "") }
       it "エラーが発生する" do
@@ -47,6 +62,22 @@ RSpec.describe User, type: :model do
       it "エラーが発生する" do
         expect(subject).to eq false
         expect(user.errors.messages[:email]).to include "は255文字以内で入力してください"
+      end
+    end
+    context "email(両方が小文字) が重複するとき" do
+      let(:user) { build(:user, email: "aaron@example.com") }
+      it "エラーが発生する" do
+        create(:user, email: "aaron@example.com")
+        expect(subject).to eq false
+        expect(user.errors.messages[:email]).to include "はすでに存在します"
+      end
+    end
+    context "email(片方が大文字、片方が小文字) が重複するとき" do
+      let(:user) { build(:user, email: "AARON@EXAMPLE.COM") }
+      it "エラーが発生する" do
+        create(:user, email: "aaron@example.com")
+        expect(subject).to eq false
+        expect(user.errors.messages[:email]).to include "はすでに存在します"
       end
     end
     context "cost が負の整数のとき" do


### PR DESCRIPTION
close #177

## 実装内容

- ゲストユーザの場合、マイページの編集および削除ボタンは表示されないようにする。
- 同じ名前のユーザが登録できないようにユーザモデルに一意制のバリデーションおよびテーブルに制約を追加。ただし、大文字と小文字の区別はする。バリデーション追加に伴い、モデルテストを追加
- 同じメールアドレスが登録できないようにユーザモデルで大文字のメールアドレスを小文字に変更するようにする。バリデーション追加に伴い、モデルテストを追加

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
