### PR TITLE
マイページにプロフィールを追加

### DIFF
--- a/app/assets/stylesheets/_users.scss
+++ b/app/assets/stylesheets/_users.scss
@@ -79,3 +79,12 @@ $sub-color-fourth: #000000;
   border: solid 1px silver;
   overflow: auto;
 }
+
+.mypage-profile{
+  width: 330px;
+  height: 270px;
+  border: solid 1px silver;
+  overflow: auto;
+  padding: 15px;
+  font-size: 1em;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
     # サインアップ時のストロングパラメータ
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :cost])
     # アカウント編集時のストロングパラメータ
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :image, :cost])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :image, :cost, :profile])
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 50 }, uniqueness: true
   validates :email, length: { maximum: 255 }, uniqueness: true
   validates :cost, numericality: { greater_than_or_equal_to: 0, only_integer: true }
+  validates :profile, length: { maximum: 160 }
 
   has_many :posts, dependent: :destroy
   has_many :likes, dependent: :destroy

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -30,6 +30,11 @@
             </div>
 
             <div class="form-group">
+              <%= f.label :profile %>
+              <%= f.text_area :profile, autocomplete: 'profile', class: 'form-control', maxlength: '160' %>
+            </div>
+
+            <div class="form-group">
               <%= f.submit t('.update'), class: 'btn btn-info btn-lg btn-block' %>
             </div>
           <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -31,7 +31,7 @@
 
             <div class="form-group">
               <%= f.label :profile %>
-              <%= f.text_area :profile, autocomplete: 'profile', class: 'form-control', maxlength: '160' %>
+              <%= f.text_area :profile, autocomplete: 'profile', class: 'form-control', maxlength: '160', size: "5x5" %>
             </div>
 
             <div class="form-group">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -62,8 +62,8 @@
     <div class="col-lg-3 ml-lg-5 mt-1 mb-5">
       <% if @user.profile.present? %>
         <h5 class=" mt-lg-5"><strong>プロフィール</strong></h5>
-        <div class="mypage-content-scroll">
-          <%= @user.profile  %>
+        <div class="mypage-profile">
+          <%= @user.profile %>
         </div>
         <br>
       <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -59,7 +59,14 @@
         </div>
       <% end %>
     </div>
-    <div class="col-lg-3 ml-lg-5 mt-5 mb-5">
+    <div class="col-lg-3 ml-lg-5 mt-1 mb-5">
+      <% if @user.profile.present? %>
+        <h5 class=" mt-lg-5"><strong>プロフィール</strong></h5>
+        <div class="mypage-content-scroll">
+          <%= @user.profile  %>
+        </div>
+        <br>
+      <% end %>
       <% if @posts.present? %>
         <h5 class=" mt-lg-5"><strong>つぶやき一覧</strong></h5>
         <div class="mypage-content-scroll">

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -28,6 +28,7 @@ ja:
         name: ユーザ名
         cost: １日のお菓子にかかっている費用
         image: プロフィール画像
+        profile: プロフィール
       admin_user: *user
     models:
       user: ユーザ

--- a/db/migrate/20211224121311_add_profile_to_users.rb
+++ b/db/migrate/20211224121311_add_profile_to_users.rb
@@ -1,0 +1,5 @@
+class AddProfileToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :profile, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_18_010913) do
+ActiveRecord::Schema.define(version: 2021_12_24_121311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 2021_12_18_010913) do
     t.integer "eat_day", default: 0
     t.date "eat_day_updated_on", default: "2021-08-29", null: false
     t.integer "eat_day_month", default: 0
+    t.text "profile"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -101,6 +101,19 @@ RSpec.describe User, type: :model do
         expect(user.errors.messages[:cost]).to include "は整数で入力してください"
       end
     end
+    context "profile が160文字のとき" do
+      let(:user) { build(:user, profile: "a" * 160) }
+      it "保存できる" do
+        expect(subject).to eq true
+      end
+    end
+    context "profile が161文字以上のとき" do
+      let(:user) { build(:user, profile: "a" * 161) }
+      it "エラーが発生する" do
+        expect(subject).to eq false
+        expect(user.errors.messages[:profile]).to include "は160文字以内で入力してください"
+      end
+    end
   end
 
   describe "インスタンスメソッド" do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -72,6 +72,11 @@ RSpec.describe "Users", type: :request do
           subject
           expect(response.body).to include user.save_money_month.to_s
         end
+
+        it "profile が表示されている" do
+          subject
+          expect(response.body).to include user.profile.to_s
+        end
       end
 
       context ":idに対応するユーザーが存在しないとき" do


### PR DESCRIPTION
close #173

## 実装内容

- ユーザが好きなプロフィールを入力可能なようにする。
- 入力したプロフィールをマイページで参照可能なようにする。
- プロフィールが入力されていない場合は、マイページに表示しない。
- プロフィールは160文字まで入力可能なようにする。
- プロフィールは編集機能から入力可能なようにする。
- プロフィールに関するリクエストスペックおよびモデルスペックを追加する。リクエストスペックはマイページにプロフィールの項目が表示されていることを確認する。モデルスペックは160文字の場合と160文字よりも多くの文字を入力した場合を実施する。


## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
