### PR TITLE
つぶやき機能にてつぶやいた日付を表示する

### DIFF
--- a/app/assets/stylesheets/_post.scss
+++ b/app/assets/stylesheets/_post.scss
@@ -22,7 +22,7 @@ $sub-color-fourth: #000000;
 
 .post-content {
   border: dotted 1px silver;
-  height: 350px;
+  height: 380px;
   margin-top: 10px;
   padding: 10px;
 }
@@ -41,12 +41,20 @@ $sub-color-fourth: #000000;
   margin: 0px auto;
   width: 60%;
   text-overflow: ellipsis;
-  height: 170px;
+  height: 200px;
+}
+
+.tweet-time {
+  display: inline;
+  float: left;
+  font-size: 18px;
+  color: rgba(0,0,0,0.6);
+  padding-left: 5px;
 }
 
 .post-icon {
   display: inline;
-  float:right
+  float: right;
 }
 
 .dislike-info {
@@ -132,7 +140,8 @@ table {
 
 .post-detail-content {
   border: dotted 1px silver;
-  height: 350px;
+  // height: 350px;
+  height: 380px;
   padding: 10px;
 }
 
@@ -171,6 +180,6 @@ table {
   }
 
   .post-detail-content {
-    height: 440px;
+    height: 450px;
   }
 }

--- a/app/assets/stylesheets/_post.scss
+++ b/app/assets/stylesheets/_post.scss
@@ -140,7 +140,6 @@ table {
 
 .post-detail-content {
   border: dotted 1px silver;
-  // height: 350px;
   height: 380px;
   padding: 10px;
 }

--- a/app/views/posts/_comment.html.erb
+++ b/app/views/posts/_comment.html.erb
@@ -17,4 +17,7 @@
   <div class="content">
     <p><%= comment.content %></p>
   </div>
+  <div class="tweet-time">
+    <%= l comment.updated_at %>
+  </div>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,38 +1,11 @@
 <div class="post-content">
   <%= display_user_icon_post(post.user, "show_image", user_path(post.user)) %>
-  <strong class="user-name">
-    <%= link_to post.user.name, user_path(post.user), class:"link_under_none" %>
-  </strong>
-  <% if current_user.id == post.user_id %>
-    <div class="dropdown">
-      <button class="btn fa fa-ellipsis-v" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      </button>
-      <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-        <%= link_to "編集", edit_post_path(post), class:"dropdown-item" %>
-        <div class="dropdown-divider"></div>
-        <%= link_to "削除", post_path(post), method: :delete, data: { confirm: "削除しますか？" }, class:"dropdown-item" %>
-      </div>
-    </div>
-  <% end %>
+  <%= render 'post_header', post: post %>
   <%= link_to(post_path(post), class: "tweet_content") do %>
     <div class="content">
       <%= post.content %>
     </div>
   <% end %>
-  <div class="tweet-time">
-    <%= l post.updated_at %>
-  </div>
-  <div class="post-icon">
-    <span id="post-<%= post.id %>">
-      <% if post.liked_by?(current_user) %>
-        <%= render "like", post: post %>
-      <% else %>
-        <%= render "dislike", post: post %>
-      <% end %>
-    </span>
-  </div>
-  <div class="comment-icon">
-    <%= link_to "", post_path(post), class:"fa fa-comment fa-lg comment-style" %>
-    <%= post.comments_count %>
-  </div>
+
+  <%= render 'post_footer', post: post %>
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -3,8 +3,8 @@
   <strong class="user-name">
     <%= link_to post.user.name, user_path(post.user), class:"link_under_none" %>
   </strong>
-  <div class="dropdown">
-    <% if current_user.id == post.user_id %>
+  <% if current_user.id == post.user_id %>
+    <div class="dropdown">
       <button class="btn fa fa-ellipsis-v" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       </button>
       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
@@ -12,13 +12,16 @@
         <div class="dropdown-divider"></div>
         <%= link_to "削除", post_path(post), method: :delete, data: { confirm: "削除しますか？" }, class:"dropdown-item" %>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
   <%= link_to(post_path(post), class: "tweet_content") do %>
     <div class="content">
       <%= post.content %>
     </div>
   <% end %>
+  <div class="tweet-time">
+    <%= l post.updated_at %>
+  </div>
   <div class="post-icon">
     <span id="post-<%= post.id %>">
       <% if post.liked_by?(current_user) %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -6,6 +6,5 @@
       <%= post.content %>
     </div>
   <% end %>
-
   <%= render 'post_footer', post: post %>
 </div>

--- a/app/views/posts/_post_footer.html.erb
+++ b/app/views/posts/_post_footer.html.erb
@@ -1,0 +1,16 @@
+<div class="tweet-time">
+  <%= l post.updated_at %>
+</div>
+<div class="post-icon">
+  <span id="post-<%= post.id %>">
+    <% if post.liked_by?(current_user) %>
+      <%= render "like", post: post %>
+    <% else %>
+      <%= render "dislike", post: post %>
+    <% end %>
+  </span>
+</div>
+<div class="comment-icon">
+  <%= link_to "", post_path(post), class:"fa fa-comment fa-lg comment-style" %>
+  <%= post.comments_count %>
+</div>

--- a/app/views/posts/_post_header.html.erb
+++ b/app/views/posts/_post_header.html.erb
@@ -1,0 +1,14 @@
+<strong class="user-name">
+  <%= link_to post.user.name, user_path(post.user), class:"link_under_none" %>
+</strong>
+<% if current_user.id == post.user_id %>
+  <div class="dropdown">
+    <button class="btn fa fa-ellipsis-v" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    </button>
+    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+      <%= link_to "編集", edit_post_path(post), class:"dropdown-item" %>
+      <div class="dropdown-divider"></div>
+      <%= link_to "削除", post_path(post), method: :delete, data: { confirm: "削除しますか？" }, class:"dropdown-item" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -11,7 +11,6 @@
         </div>
         <%= render 'post_footer', post: @post %>
       </div>
-
       <%= render partial: 'comment', collection: @post.comments %>
       <%= link_to("戻る", posts_path,  class: "btn btn-secondary btn-lg btn-block btn-back mt-4") %>
     </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -5,40 +5,11 @@
       <%= link_to "コメントする", new_post_comments_path(@post), class: "btn btn-primary btn-lg btn-block btn-twitter" %>
       <div class="post-detail-content">
         <%= display_user_icon_post(@post.user, "show_image", user_path(@post.user)) %>
-        <strong class="user-name">
-          <%= link_to @post.user.name, user_path(@post.user), class:"link_under_none" %>
-        </strong>
-        <% if current_user.id == @post.user_id %>
-          <div class="dropdown">
-            <button class="btn fa fa-ellipsis-v" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            </button>
-            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-              <%= link_to "編集", edit_post_path(@post), class:"dropdown-item" %>
-              <div class="dropdown-divider"></div>
-              <%= link_to "削除", post_path(@post), method: :delete, data: { confirm: "削除しますか？" }, class:"dropdown-item" %>
-            </div>
-          </div>
-        <% end %>
+        <%= render 'post_header', post: @post %>
         <div class="content">
           <p><%= @post.content %></p>
         </div>
-
-        <div class="tweet-time">
-          <%= l @post.updated_at %>
-        </div>
-        <div class="post-icon">
-          <span id="post-<%= @post.id %>">
-            <% if @post.liked_by?(current_user) %>
-              <%= render "like", post: @post %>
-            <% else %>
-              <%= render "dislike", post: @post %>
-            <% end %>
-          </span>
-        </div>
-        <div class="comment-icon">
-          <span class="fa fa-comment fa-lg comment-style"></span>
-          <%= @post.comments.count %>
-        </div>
+        <%= render 'post_footer', post: @post %>
       </div>
 
       <%= render partial: 'comment', collection: @post.comments %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -23,6 +23,9 @@
           <p><%= @post.content %></p>
         </div>
 
+        <div class="tweet-time">
+          <%= l @post.updated_at %>
+        </div>
         <div class="post-icon">
           <span id="post-<%= @post.id %>">
             <% if @post.liked_by?(current_user) %>


### PR DESCRIPTION
close #179

## 実装内容

- つぶやき機能にて、つぶやいた日付を表示するようにする。postsテーブルのupdated_atを表示するようにする。日付を表示させることによって、つぶやいた情報がいつの時のものかをユーザにわかるようにするため
- 「_post.html.erb」、「_show.html.erb」の共通化可能な箇所をパーシャル化する。

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
