### PR TITLE
CircleCiでAWSにデプロイ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,3 +34,23 @@ jobs:
       - run:
           name: run tests
           command: bundle exec rspec
+
+  deploy:
+    docker:
+      - image: circleci/ruby:2.7.2-node
+    steps:
+      - add_ssh_keys:
+          fingerprints: "23:3a:d8:a5:c8:eb:64:f9:3f:aa:d8:0b:0d:60:fa:50"
+
+workflows:
+  version: 2
+  build_deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints: "23:3a:d8:a5:c8:eb:64:f9:3f:aa:d8:0b:0d:60:fa:50"
+      - deploy:
+          name: Capistrano deploy
+          command: bundle exec cap production deploy
 
 workflows:
   version: 2.1
@@ -50,3 +53,7 @@ workflows:
       - deploy:
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,14 +43,10 @@ jobs:
           fingerprints: "23:3a:d8:a5:c8:eb:64:f9:3f:aa:d8:0b:0d:60:fa:50"
 
 workflows:
-  version: 2
+  version: 2.1
   build_deploy:
     jobs:
       - build
       - deploy:
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - develop

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -63,7 +63,7 @@
 server "13.115.210.86", user: "stop_sweets_user", roles: %w{app db web}
 
 set :ssh_options, {
-  keys: %w(~/.ssh/stop_sweets.pem),
+  keys: [ENV.fetch('PRODUCTION_SSH_KEY').to_s],
   forward_agent: true,
   auth_methods: %w(publickey),
 }


### PR DESCRIPTION
close #194

## 実装内容

- developブランチにマージされたら、CircleCiでCapistranoを使用して、AWSにデプロイするように修正

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
