### PR TITLE
developブランチにマージされたら、AWSにデプロイするように修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,12 @@ jobs:
     docker:
       - image: circleci/ruby:2.7.2-node
     steps:
+      - checkout
+      - run:
+          name: install dependencies
+          command: |
+            gem install bundler -v 2.2.11
+            bundle install --jobs=4 --retry=3
       - add_ssh_keys:
           fingerprints: "23:3a:d8:a5:c8:eb:64:f9:3f:aa:d8:0b:0d:60:fa:50"
       - deploy:


### PR DESCRIPTION
close #196 

## 実装内容

- featureブランチからdevelopブランチにマージされたら、AWSにデプロイされるようにする。
- CirlcleCiのデプロイ環境でプログラムをチェックアウト、bundle installするように修正。

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
