### PR TITLE
developブランチをAWSにデプロイするように修正。また、秘密鍵のファイル名を修正

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,7 +4,7 @@ lock "~> 3.16.0"
 set :application, "stop_sweets"
 set :repo_url, "git@github.com:YokoyamaGen/stop_sweets.git"
 set :rbenv_ruby, File.read('.ruby-version').strip
-set :branch, ENV['BRANCH'] || "main"
+set :branch, ENV['BRANCH'] || "develop"
 
 set :nginx_config_name, "#{fetch(:application)}.conf"
 set :nginx_sites_enabled_path, "/etc/nginx/conf.d"

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -63,7 +63,7 @@
 server "13.115.210.86", user: "stop_sweets_user", roles: %w{app db web}
 
 set :ssh_options, {
-  keys: [ENV.fetch('PRODUCTION_SSH_KEY').to_s],
+  keys: %w(~/.ssh/id_rsa_233ad8a5c8eb64f93faad80b0d60fa50),
   forward_agent: true,
   auth_methods: %w(publickey),
 }


### PR DESCRIPTION
close #198 

## 実装内容

- developブランチをAWSにデプロイするように修正。deploy.rbのBRANCHをmainからdevelopに修正。
- circleciで秘密鍵を使用できるように秘密鍵のファイル名を修正。

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
