### PR TITLE
CircleCiからAWSのデプロイエラー対応

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,6 @@ default: &default
   host: db
   user: postgres
   port: 5432
-  password: <%= ENV.fetch("DATABASE_PASSWORD") %>
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
@@ -28,6 +27,7 @@ default: &default
 development:
   <<: *default
   database: stop_sweets_development
+  password: <%= ENV.fetch("DATABASE_PASSWORD") %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -63,6 +63,7 @@ test:
   <<: *default
   database: stop_sweets_test
   host: <%= ENV.fetch("APP_DATABASE_HOST") { 'db' } %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD") %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
close #200

## 実装内容

- CircleCiからAWSのデプロイエラー原因がdatabase.ymlの本番環境用パスワードで使用されているDATABASE_PASSWORDが不要なため、本番環境ではDATABASE_PASSWORDを使用しないようにする。

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
