### PR TITLE
デフォルトのデータベースパスワードの設定方法を変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,10 @@ jobs:
       - add_ssh_keys:
           fingerprints: "23:3a:d8:a5:c8:eb:64:f9:3f:aa:d8:0b:0d:60:fa:50"
       - run: cd /home/circleci/project
+      - run: pwd
       - deploy:
           name: Capistrano deploy
-          command: bundle exec cap production deploy --trace --dry-run
+          command: bundle exec cap production deploy
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
         environment:
           POSTGRES_DB: stop_sweets_test
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD:  postgres
+          POSTGRES_PASSWORD: postgres
     environment:
       APP_DATABASE_HOST: "127.0.0.1"
       RAILS_ENV: test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,7 @@ jobs:
       - add_ssh_keys:
           fingerprints: "23:3a:d8:a5:c8:eb:64:f9:3f:aa:d8:0b:0d:60:fa:50"
       - run: cd /home/circleci/project
-      - run: pwd
-      - deploy:
+      - run:
           name: Capistrano deploy
           command: bundle exec cap production deploy
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ jobs:
   deploy:
     docker:
       - image: circleci/ruby:2.7.2-node
+    environment:
+      DATABASE_PASSWORD: postgres
     steps:
       - checkout
       - run:
@@ -47,7 +49,6 @@ jobs:
             bundle install --jobs=4 --retry=3
       - add_ssh_keys:
           fingerprints: "23:3a:d8:a5:c8:eb:64:f9:3f:aa:d8:0b:0d:60:fa:50"
-      - run: cd /home/circleci/project
       - run:
           name: Capistrano deploy
           command: bundle exec cap production deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,9 @@ jobs:
           command: |
             gem install bundler -v 2.2.11
             bundle install --jobs=4 --retry=3
-      - run: yarn install
       - add_ssh_keys:
           fingerprints: "23:3a:d8:a5:c8:eb:64:f9:3f:aa:d8:0b:0d:60:fa:50"
+      - run: cd /home/circleci/project
       - deploy:
           name: Capistrano deploy
           command: bundle exec cap production deploy
@@ -63,7 +63,3 @@ workflows:
       - deploy:
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,3 +59,7 @@ workflows:
       - deploy:
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,6 @@ jobs:
   deploy:
     docker:
       - image: circleci/ruby:2.7.2-node
-    environment:
-      RAILS_ENV: production
-      DATABASE_PASSWORD: postgres
     steps:
       - checkout
       - run:
@@ -53,7 +50,7 @@ jobs:
       - run: cd /home/circleci/project
       - deploy:
           name: Capistrano deploy
-          command: bundle exec cap production deploy
+          command: bundle exec cap production deploy --trace --dry-run
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,6 @@ jobs:
   deploy:
     docker:
       - image: circleci/ruby:2.7.2-node
-    environment:
-      DATABASE_PASSWORD: postgres
     steps:
       - checkout
       - run:
@@ -49,6 +47,7 @@ jobs:
             bundle install --jobs=4 --retry=3
       - add_ssh_keys:
           fingerprints: "23:3a:d8:a5:c8:eb:64:f9:3f:aa:d8:0b:0d:60:fa:50"
+      - run: export DATABASE_PASSWORD=postgres
       - run:
           name: Capistrano deploy
           command: bundle exec cap production deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
         environment:
           POSTGRES_DB: stop_sweets_test
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD:  postgres
     environment:
       APP_DATABASE_HOST: "127.0.0.1"
       RAILS_ENV: test
@@ -47,7 +47,6 @@ jobs:
             bundle install --jobs=4 --retry=3
       - add_ssh_keys:
           fingerprints: "23:3a:d8:a5:c8:eb:64:f9:3f:aa:d8:0b:0d:60:fa:50"
-      - run: export DATABASE_PASSWORD=postgres
       - run:
           name: Capistrano deploy
           command: bundle exec cap production deploy

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,6 @@ default: &default
   host: db
   user: postgres
   port: 5432
-  password: postgres
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,7 @@ default: &default
   host: db
   user: postgres
   port: 5432
+  password: postgres
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,7 @@ default: &default
   host: db
   user: postgres
   port: 5432
-  password: <%= ENV.fetch("DATABASE_PASSWORD") %>
+  password: postgres
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>


### PR DESCRIPTION
close #208

## 実装内容

- CircleCiからAWSへデプロイする際に、デフォルトのデータベースパスワードが原因でエラーが出てしまうため、デフォルトのデータベースパスワードの設定方法を変更

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
